### PR TITLE
chore(deps): bump @grpc/grpc-js in /hello-grpc-ts to ^1.14.0

### DIFF
--- a/hello-grpc-ts/package.json
+++ b/hello-grpc-ts/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@grpc/grpc-js": "^1.12.0",
+    "@grpc/grpc-js": "^1.14.0",
     "fast-linked-list": "^3.2.3",
     "google-protobuf": "^3.21.4",
     "uuid": "^11.0.2",


### PR DESCRIPTION
Closes the same 2 Snyk H vulnerabilities as #476 (SNYK-JS-GRPCGRPCJS-17315972 and -17315646). Range ^1.12.0 was inside both vulnerable windows; bumping the caret to 1.14.x lets consumer installs pull 1.14.4.

Separate PR from the nodejs sibling because the two package.json files are not bundled by a workspace root; combining them would defeat dependabot's per-subproject bump semantics.