### PR TITLE
chore(deps): bump grpc/grpc in /hello-grpc-php to ^1.74.0

### DIFF
--- a/hello-grpc-php/composer.json
+++ b/hello-grpc-php/composer.json
@@ -2,7 +2,7 @@
     "name": "feuyeux/hello-grpc",
     "description": "Hello gRPC for PHP",
     "require": {
-        "grpc/grpc": "^1.57.0",
+        "grpc/grpc": "^1.74.0",
         "google/protobuf": "^v4.0.0",
         "ramsey/uuid": "^4.7.5",
         "monolog/monolog": "^3.5.0"


### PR DESCRIPTION
Closes 3 years of accumulated gRPC C-extension security and stability patches. 1.57.0 (Aug 2023) -> 1.74.0+ (Jul 2025+) = ~24 minor versions behind the upstream Packagist line (1.81.0 as of 2026-06-01).

Why 1.74.0 not 1.81.0: 1.74.0 was the first version with the current PHP >=7.1.0 floor (no major PHP rewrite needed). Pinning at the minimum bump keeps the diff minimal and easily backportable.

composer.lock is .gitignore'd via '*.lock' rule, so the lockfile regeneration will happen on consumer install / CI. The new manifest range ^1.74.0 lets 'composer update' pull 1.81.0 (the latest) on first clean install.