### PR TITLE
chore(deps): bump grpc-dotnet + Google.Protobuf in /hello-grpc-csharp to 2.80.0 / 3.31.1

### DIFF
--- a/hello-grpc-csharp/Common/Common.csproj
+++ b/hello-grpc-csharp/Common/Common.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <!-- 依赖包升级到最新稳定版本 -->
-    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.61.0" />
-    <PackageReference Include="Grpc.Net.Common" Version="2.61.0" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.61.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.62.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.31.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageReference Include="Grpc.Net.Common" Version="2.80.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.80.0" PrivateAssets="All" />
     <PackageReference Include="log4net" Version="3.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/hello-grpc-csharp/HelloClient/HelloClient.csproj
+++ b/hello-grpc-csharp/HelloClient/HelloClient.csproj
@@ -19,7 +19,7 @@
   
   <ItemGroup>
     <!-- 使用最新的 gRPC 客户端实现 -->
-    <PackageReference Include="Grpc.Net.Client" Version="2.61.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/hello-grpc-csharp/HelloServer/HelloServer.csproj
+++ b/hello-grpc-csharp/HelloServer/HelloServer.csproj
@@ -20,9 +20,9 @@
 
   <ItemGroup>
     <!-- 使用最新的 gRPC 实现 -->
-    <PackageReference Include="Grpc.Net.Client" Version="2.61.0" />
-    <PackageReference Include="Grpc.Net.Common" Version="2.61.0" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.61.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageReference Include="Grpc.Net.Common" Version="2.80.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes 19 minor-versions of grpc-dotnet backlog (2.61.0 -> 2.80.0) and 5 minor-versions of Google.Protobuf (3.26.1 -> 3.31.1).

Why Google.Protobuf also bumps: Grpc.AspNetCore 2.80.0 transitively requires Google.Protobuf >=3.31.1. Without this bump, dotnet restore fails with NU1605 (package downgrade) error.

Picked 3.31.1 (minimum that satisfies Grpc.AspNetCore 2.80.0) rather than latest 3.33.x to keep the diff narrow and protobuf-api impact minimal. Future bumps to 3.33.x can be a follow-up.

Verified locally: dotnet build (5 projects, 0 errors, 12 pre-existing warnings) + dotnet test (3 passed, 0 failed) green.