### PR TITLE
fix(nodejs,ts): correct broken import paths and add missing grpc-js stub

### DIFF
--- a/hello-grpc-nodejs/test/utils.test.js
+++ b/hello-grpc-nodejs/test/utils.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const { getVersion } = require('../common/utils');
+const { getVersion } = require('../src/common/utils');
 
 // Directly output the getVersion() result
 console.log(getVersion());

--- a/hello-grpc-ts/src/hello_client.ts
+++ b/hello-grpc-ts/src/hello_client.ts
@@ -12,10 +12,10 @@
  */
 
 import * as grpc from '@grpc/grpc-js';
-import { TalkRequest, TalkResponse } from './generated/landing_pb';
+import { TalkRequest, TalkResponse } from './proto/landing_pb';
 import { logger } from './lib/conn';
 import { buildLinkRequests, getVersion, randomId } from './lib/utils';
-import { LandingServiceClient } from './generated/landing_grpc_pb';
+import { LandingServiceClient } from './proto/landing_grpc_pb';
 import { createClientCredentials } from './lib/tls';
 
 // Configuration constants

--- a/hello-grpc-ts/src/hello_server.ts
+++ b/hello-grpc-ts/src/hello_server.ts
@@ -1,7 +1,7 @@
 import * as grpc from '@grpc/grpc-js'
 import { sendUnaryData } from '@grpc/grpc-js/build/src/server-call'
-import { ILandingServiceServer, LandingServiceService } from "./generated/landing_grpc_pb"
-import { ResultType, TalkRequest, TalkResponse, TalkResult } from "./generated/landing_pb"
+import { ILandingServiceServer, LandingServiceService } from "./proto/landing_grpc_pb"
+import { ResultType, TalkRequest, TalkResponse, TalkResult } from "./proto/landing_pb"
 import { v4 as uuidv4 } from "uuid"
 import { ans, getVersion, hellos } from "./lib/utils"
 import { createClient, getServerPort, logger } from "./lib/conn"

--- a/hello-grpc-ts/src/lib/conn.ts
+++ b/hello-grpc-ts/src/lib/conn.ts
@@ -3,7 +3,7 @@ import {createLogger, format, transports} from "winston";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import {LandingServiceClient} from "../generated/landing_grpc_pb";
+import {LandingServiceClient} from "../proto/landing_grpc_pb";
 
 // 定义默认端口
 export const port = "9996";

--- a/hello-grpc-ts/src/lib/utils.ts
+++ b/hello-grpc-ts/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { TalkRequest } from "../generated/landing_pb"
+import { TalkRequest } from "../proto/landing_pb"
 import { LinkedList } from "fast-linked-list";
 import * as grpc from '@grpc/grpc-js'
 import * as fs from 'fs'

--- a/hello-grpc-ts/src/proto/landing_grpc_pb.js
+++ b/hello-grpc-ts/src/proto/landing_grpc_pb.js
@@ -1,0 +1,81 @@
+// GENERATED CODE -- DO NOT EDIT!
+
+'use strict';
+var grpc = require('@grpc/grpc-js');
+var landing_pb = require('./landing_pb.js');
+
+function serialize_hello_TalkRequest(arg) {
+  if (!(arg instanceof landing_pb.TalkRequest)) {
+    throw new Error('Expected argument of type hello.TalkRequest');
+  }
+  return Buffer.from(arg.serializeBinary());
+}
+
+function deserialize_hello_TalkRequest(buffer_arg) {
+  return landing_pb.TalkRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_hello_TalkResponse(arg) {
+  if (!(arg instanceof landing_pb.TalkResponse)) {
+    throw new Error('Expected argument of type hello.TalkResponse');
+  }
+  return Buffer.from(arg.serializeBinary());
+}
+
+function deserialize_hello_TalkResponse(buffer_arg) {
+  return landing_pb.TalkResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+
+var LandingServiceService = exports.LandingServiceService = {
+  // Unary RPC
+talk: {
+    path: '/hello.LandingService/Talk',
+    requestStream: false,
+    responseStream: false,
+    requestType: landing_pb.TalkRequest,
+    responseType: landing_pb.TalkResponse,
+    requestSerialize: serialize_hello_TalkRequest,
+    requestDeserialize: deserialize_hello_TalkRequest,
+    responseSerialize: serialize_hello_TalkResponse,
+    responseDeserialize: deserialize_hello_TalkResponse,
+  },
+  // Server streaming RPC
+talkOneAnswerMore: {
+    path: '/hello.LandingService/TalkOneAnswerMore',
+    requestStream: false,
+    responseStream: true,
+    requestType: landing_pb.TalkRequest,
+    responseType: landing_pb.TalkResponse,
+    requestSerialize: serialize_hello_TalkRequest,
+    requestDeserialize: deserialize_hello_TalkRequest,
+    responseSerialize: serialize_hello_TalkResponse,
+    responseDeserialize: deserialize_hello_TalkResponse,
+  },
+  // Client streaming RPC with random & sleep
+talkMoreAnswerOne: {
+    path: '/hello.LandingService/TalkMoreAnswerOne',
+    requestStream: true,
+    responseStream: false,
+    requestType: landing_pb.TalkRequest,
+    responseType: landing_pb.TalkResponse,
+    requestSerialize: serialize_hello_TalkRequest,
+    requestDeserialize: deserialize_hello_TalkRequest,
+    responseSerialize: serialize_hello_TalkResponse,
+    responseDeserialize: deserialize_hello_TalkResponse,
+  },
+  // Bidirectional streaming RPC
+talkBidirectional: {
+    path: '/hello.LandingService/TalkBidirectional',
+    requestStream: true,
+    responseStream: true,
+    requestType: landing_pb.TalkRequest,
+    responseType: landing_pb.TalkResponse,
+    requestSerialize: serialize_hello_TalkRequest,
+    requestDeserialize: deserialize_hello_TalkRequest,
+    responseSerialize: serialize_hello_TalkResponse,
+    responseDeserialize: deserialize_hello_TalkResponse,
+  },
+};
+
+exports.LandingServiceClient = grpc.makeGenericClientConstructor(LandingServiceService, 'LandingService');


### PR DESCRIPTION
Surface-level pre-existing CI failures discovered during the
@aSnyk/grpcio/dep-bump audit (PRs #476-#479). Both broken since at
least 2025-08-10 (the last commit that touched these files), and
the bump-branch CI for #476 surfaced them as additional noise on top
of the more general CI-red situation.

What changes
- hello-grpc-nodejs/test/utils.test.js: require '../common/utils'
  -> '../src/common/utils' (test ran from ./test/, ../common did not
  exist; src/common/utils.js was the real path).
- hello-grpc-ts/src/{hello_client,hello_server}.ts and src/lib/{conn,
  utils}.ts: 6 imports rewritten from './generated/landing_*pb' to
  './proto/landing_*pb' (no 'generated' dir has ever existed; the
  generated stub dir has always been './proto/').
- hello-grpc-ts/src/proto/landing_grpc_pb.js: added (grpc-js server
  stub exporting LandingServiceService + LandingServiceClient).
  Sibling d.ts was already in the repo; the .js was missing despite
  being required at runtime. Copied from the protobuf build of the
  sibling hello-grpc-nodejs tree (same protoc invocation, same
  upstream landing.proto, identical runtime requirements).

What does NOT change
- src/proto/landing_grpc_pb.d.ts still says
  'import grpc from "grpc"' (the legacy package). On the Linux CI
  runner 'npm run generate-proto' rebuilds it against
  @grpc/grpc-js and produces the correct types. This commit makes
  the .ts import paths line up so that regen can be added
  mechanically later without other .ts changes.
- No production-code behavior change; only test file path + 6
  rewrite-the-existing-import statement changes + 1 new grpc-js
  artifact.

Local verification
- hello-grpc-nodejs: 'npm test' runs the 2 getVersion() assertions
  green. Test output is 'grpc.version=1.14.4', which is independent
  confirmation the @grpc/grpc-js 1.14.0 bump from #476 is correctly
  active end-to-end.
- hello-grpc-ts: 'npm run build' NOT exercised locally because this
  Windows host lacks a working protoc-gen-ts shim (a known grpc-tools
  limitation on Windows). On a Linux/macOS runner the rewrite removes
  the module-not-found errors and the existing 'tsc --outDir dist'
  step will compile.

Risk
- Lowest-possible: it's a path fix + 1 missing generated artifact in a
  tree that is already broken without the fix. Worst case the CI
  surface no longer shifts; existing CI red will remain red for the
  reasons already known (see PR #476 CI logs).