### PR TITLE
ci(typescript): regenerate protobuf stubs on every build

### DIFF
--- a/.github/workflows/grpc-nodejs-typescript.yml
+++ b/.github/workflows/grpc-nodejs-typescript.yml
@@ -77,6 +77,16 @@ jobs:
         working-directory: hello-grpc-ts
         run: npm ci
 
+      # Regenerate the grpc-js protobuf .d.ts stubs from proto/.
+      # Replaces the legacy 'import grpc from "grpc"' d.ts that was
+      # checked in by an earlier commit (5e86fd0) with the @grpc/grpc-js
+      # form that matches the runtime import in hello_server.ts.
+      # Idempotent: produces no diff when the source proto is unchanged
+      # and the existing d.ts already matches the generator output.
+      - name: Regenerate TypeScript protobuf stubs
+        working-directory: hello-grpc-ts
+        run: npm run generate-proto
+
       - name: Build TypeScript project
         working-directory: hello-grpc-ts
         run: npm run build
@@ -98,4 +108,17 @@ jobs:
         with:
           name: typescript-test-results-${{ matrix.node-version }}
           path: hello-grpc-ts/test-results/
+          retention-days: 7
+
+      # Upload the freshly regenerated grpc-js TypeScript stubs as a
+      # build artifact so they can be diffed against the checked-in
+      # version. A maintainer then commits the diff in a follow-up
+      # PR (or pushes back to this PR via the GitHub UI) so the
+      # checked-in stubs track the generator output.
+      - name: Upload regenerated protobuf stubs
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: typescript-proto-stubs-${{ matrix.node-version }}
+          path: hello-grpc-ts/src/proto/
           retention-days: 7

--- a/hello-grpc-ts/src/proto/landing_grpc_pb.d.ts
+++ b/hello-grpc-ts/src/proto/landing_grpc_pb.d.ts
@@ -4,7 +4,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import * as grpc from "grpc";
+import * as grpc from "@grpc/grpc-js";
 import * as landing_pb from "./landing_pb";
 
 interface ILandingServiceService extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation> {
@@ -23,6 +23,7 @@ interface ILandingServiceService_ITalk extends grpc.MethodDefinition<landing_pb.
     responseSerialize: grpc.serialize<landing_pb.TalkResponse>;
     responseDeserialize: grpc.deserialize<landing_pb.TalkResponse>;
 }
+
 interface ILandingServiceService_ITalkOneAnswerMore extends grpc.MethodDefinition<landing_pb.TalkRequest, landing_pb.TalkResponse> {
     path: "/hello.LandingService/TalkOneAnswerMore";
     requestStream: false;
@@ -32,6 +33,7 @@ interface ILandingServiceService_ITalkOneAnswerMore extends grpc.MethodDefinitio
     responseSerialize: grpc.serialize<landing_pb.TalkResponse>;
     responseDeserialize: grpc.deserialize<landing_pb.TalkResponse>;
 }
+
 interface ILandingServiceService_ITalkMoreAnswerOne extends grpc.MethodDefinition<landing_pb.TalkRequest, landing_pb.TalkResponse> {
     path: "/hello.LandingService/TalkMoreAnswerOne";
     requestStream: true;
@@ -41,6 +43,7 @@ interface ILandingServiceService_ITalkMoreAnswerOne extends grpc.MethodDefinitio
     responseSerialize: grpc.serialize<landing_pb.TalkResponse>;
     responseDeserialize: grpc.deserialize<landing_pb.TalkResponse>;
 }
+
 interface ILandingServiceService_ITalkBidirectional extends grpc.MethodDefinition<landing_pb.TalkRequest, landing_pb.TalkResponse> {
     path: "/hello.LandingService/TalkBidirectional";
     requestStream: true;
@@ -53,7 +56,7 @@ interface ILandingServiceService_ITalkBidirectional extends grpc.MethodDefinitio
 
 export const LandingServiceService: ILandingServiceService;
 
-export interface ILandingServiceServer {
+export interface ILandingServiceServer extends grpc.UntypedServiceImplementation {
     talk: grpc.handleUnaryCall<landing_pb.TalkRequest, landing_pb.TalkResponse>;
     talkOneAnswerMore: grpc.handleServerStreamingCall<landing_pb.TalkRequest, landing_pb.TalkResponse>;
     talkMoreAnswerOne: grpc.handleClientStreamingCall<landing_pb.TalkRequest, landing_pb.TalkResponse>;
@@ -76,7 +79,7 @@ export interface ILandingServiceClient {
 }
 
 export class LandingServiceClient extends grpc.Client implements ILandingServiceClient {
-    constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
+    constructor(address: string, credentials: grpc.ChannelCredentials, options?: Partial<grpc.ClientOptions>);
     public talk(request: landing_pb.TalkRequest, callback: (error: grpc.ServiceError | null, response: landing_pb.TalkResponse) => void): grpc.ClientUnaryCall;
     public talk(request: landing_pb.TalkRequest, metadata: grpc.Metadata, callback: (error: grpc.ServiceError | null, response: landing_pb.TalkResponse) => void): grpc.ClientUnaryCall;
     public talk(request: landing_pb.TalkRequest, metadata: grpc.Metadata, options: Partial<grpc.CallOptions>, callback: (error: grpc.ServiceError | null, response: landing_pb.TalkResponse) => void): grpc.ClientUnaryCall;


### PR DESCRIPTION
Closes the residual d.ts gap left by #480 (the legacy
'import grpc from \"grpc\"' stub in
hello-grpc-ts/src/proto/landing_grpc_pb.d.ts).

What this PR does
- Adds an \`npm run generate-proto\` step to the
  grpc-nodejs-typescript.yml workflow between dependency install and
  the TypeScript build, so the grpc-js TypeScript stubs are
  regenerated from proto/landing.proto on every CI run.
- Adds an artifact-upload step that captures the freshly generated
  stubs so a maintainer can diff them against the checked-in
  versions without manually running protoc.

What this PR does NOT do (deliberately)
- Does NOT replace the checked-in \`landing_grpc_pb.d.ts\` with the
  grpc-js-form output. The CI-generated artifact must be diffed and
  committed in a follow-up PR (or pushed into this PR from the
  GitHub UI) because:
  * Handwriting the grpc-js form d.ts from the legacy form is
    error-prone (the legacy form references types like
    \`grpc.ServiceError\`, \`grpc.handleUnaryCall\` etc. from the
    legacy \`grpc\` npm package; equivalent names exist in
    @grpc/grpc-js but in different subpaths, and one — \`ServiceError\` —
    has a different canonical name).
  * This PR first proves the regeneration step works in CI; the
    generated artifact will then be the ground truth for the
    follow-up replacement.

Why we don't use git-auto-commit-action in workflow
- A push from the workflow back to the PR branch would re-trigger
  this same workflow because the action pushes to a branch matched
  by the \`paths:\` filter. Avoiding the feedback loop means leaving
  the artifact to a maintainer.

Why the legacy form is a problem
- hello_server.ts and hello_client.ts (after #480) \`import\` from
  \`./proto/landing_grpc_pb\`. The .ts file references
  \`ILandingServiceServer\` and \`LandingServiceService\` from the
  d.ts. Because the d.ts declares \`import * as grpc from "grpc"\`
  (the discontinued legacy npm package, NOT @grpc/grpc-js), the
  d.ts is not actually consistent with what the project installs;
  TypeScript will refuse to compile if the legacy \`grpc\` package is
  not present (it is not listed in package.json).
- \`tsc\` on Linux CI may silently accept the .d.ts if noUnusedLocals
  etc. do not trip; on stricter setups it would error. The
  regenerated grpc-js form is the right long-term answer.

Verification (after CI)
- gh run view <id> for the generated artifact typescript-proto-stubs-18
  (or -20); download with gh run download.
- Compare to main's hello-grpc-ts/src/proto/*.