### PR TITLE
ci: remove broken npm cache config from setup-node steps

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -101,8 +101,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: hello-grpc-tauri/package-lock.json
+        # cache: 'npm' removed: hello-grpc-tauri/package-lock.json is
+        # .gitignore'd (see '*.lock' rule) and not present on fresh CI
+        # runners. The older config failed with 'Some specified paths
+        # were not resolved, unable to cache dependencies.' and silently
+        # aborted the rest of the job. npm ci installs cold each run.
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/flutter-tauri-deps.yml
+++ b/.github/workflows/flutter-tauri-deps.yml
@@ -104,8 +104,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
-          cache: 'npm'
-          cache-dependency-path: hello-grpc-tauri/package-lock.json
+        # cache: 'npm' removed: hello-grpc-tauri/package-lock.json is
+        # .gitignore'd (see '*.lock' rule) and not present on fresh CI
+        # runners. The older config failed setup-node with 'Some
+        # specified paths were not resolved, unable to cache
+        # dependencies.' npm ci installs cold each run.
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/grpc-nodejs-typescript.yml
+++ b/.github/workflows/grpc-nodejs-typescript.yml
@@ -36,8 +36,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: hello-grpc-nodejs/package-lock.json
+        # cache: 'npm' removed: hello-grpc-{nodejs,ts}/package-lock.json
+        # files are .gitignore'd (see '*.lock' rule) and not present on
+        # fresh CI runners. The older config failed setup-node with
+        # 'Some specified paths were not resolved, unable to cache
+        # dependencies.' and silently aborted the rest of the job.
+        # npm ci installs cold each run.
 
       - name: Install Node.js dependencies
         working-directory: hello-grpc-nodejs
@@ -70,8 +74,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          cache-dependency-path: hello-grpc-ts/package-lock.json
+        # cache: 'npm' removed: see nodejs-build-test step above.
 
       - name: Install TypeScript dependencies
         working-directory: hello-grpc-ts


### PR DESCRIPTION
Removes the \`cache: 'npm'\` + \`cache-dependency-path:\` config pair
from three setup-node steps. The pointed-to files
(hello-grpc-{tauri,nodejs,ts}/package-lock.json) are .gitignore'd
(see 'package-lock.json' rule in .gitignore) and therefore not
present on fresh CI runners.

The setup-node action then errors with
\`Some specified paths were not resolved, unable to cache dependencies.\`
and silently aborts the rest of the job — including \`npm ci\`, all
subsequent build/test/generate/upload steps. The CI has been
effectively red across Node.js + TypeScript + Tauri since the
lockfile was .gitignore'd.

\`npm ci\` installs cold each run, slower than a hit cache but
correct. Future tightening can move to a content-hashed cache key
once a lockfile is committed.

Workflows touched:
- .github/workflows/build-test.yml (hello-grpc-tauri cache)
- .github/workflows/flutter-tauri-deps.yml (hello-grpc-tauri cache)
- .github/workflows/grpc-nodejs-typescript.yml (both hello-grpc-nodejs
  and hello-grpc-ts caches)

grpc-go.yml and grpc-python.yml have a similar cache-dependency-path
field but lack an explicit \`cache:\` setting — setup-node's default
behavior is to skip caching altogether, so they don't trip the
failure. Left untouched here to keep this PR scoped.

Verification after merge: a re-run of grpc-nodejs-typescript should
now proceed past Setup Node.js to npm ci / generate-proto / npm run
build / npm test (and the artifact uploads). If those subsequent
steps turn up other pre-existing failures, those will be addressed
in follow-ups.