### PR TITLE
feat(proto): vendor grpc.health.v1 + grpc.reflection.v1alpha

### DIFF
--- a/proto/health/v1/health.proto
+++ b/proto/health/v1/health.proto
@@ -1,0 +1,87 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+option csharp_namespace = "Grpc.Health.V1";
+option go_package = "google.golang.org/grpc/health/grpc_health_v1";
+option java_multiple_files = true;
+option java_outer_classname = "HealthProto";
+option java_package = "io.grpc.health.v1";
+option objc_class_prefix = "GrpcHealthV1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+message HealthListRequest {}
+
+message HealthListResponse {
+  // statuses contains all the services and their respective status.
+  map<string, HealthCheckResponse.ServingStatus> statuses = 1;
+}
+
+// Health is gRPC's mechanism for checking whether a server is able to handle
+// RPCs. Its semantics are documented in
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
+service Health {
+  // Check gets the health of the specified service. If the requested service
+  // is unknown, the call will fail with status NOT_FOUND.
+  //
+  // Clients should set a deadline when calling Check, and can declare the
+  // server unhealthy if they do not receive a timely response.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // List provides a non-atomic snapshot of the health of all the available
+  // services.
+  //
+  // The server may respond with a RESOURCE_EXHAUSTED error if too many services
+  // exist.
+  //
+  // Clients should set a deadline when calling List, and can declare the server
+  // unhealthy if they do not receive a timely response.
+  //
+  // Clients should keep in mind that the list of health services exposed by an
+  // application can change over the lifetime of the process.
+  rpc List(HealthListRequest) returns (HealthListResponse);
+
+  // Performs a watch for the serving status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // serving status. It will then subsequently send a new message whenever
+  // the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call. If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/proto/reflection/v1alpha/reflection.proto
+++ b/proto/reflection/v1alpha/reflection.proto
@@ -1,0 +1,145 @@
+// Copyright 2016 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Service exported by server reflection
+
+
+// Warning: this entire file is deprecated. Use this instead:
+// https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
+
+syntax = "proto3";
+
+package grpc.reflection.v1alpha;
+
+option deprecated = true;
+option go_package = "google.golang.org/grpc/reflection/grpc_reflection_v1alpha";
+option java_multiple_files = true;
+option java_package = "io.grpc.reflection.v1alpha";
+option java_outer_classname = "ServerReflectionProto";
+
+service ServerReflection {
+  // The reflection service is structured as a bidirectional stream, ensuring
+  // all related requests go to a single server.
+  rpc ServerReflectionInfo(stream ServerReflectionRequest)
+      returns (stream ServerReflectionResponse);
+}
+
+// The message sent by the client when calling ServerReflectionInfo method.
+message ServerReflectionRequest {
+  string host = 1;
+  // To use reflection service, the client should set one of the following
+  // fields in message_request. The server distinguishes requests by their
+  // defined field and then handles them using corresponding methods.
+  oneof message_request {
+    // Find a proto file by the file name.
+    string file_by_filename = 3;
+
+    // Find the proto file that declares the given fully-qualified symbol name.
+    // This field should be a fully-qualified symbol name
+    // (e.g. <package>.<service>[.<method>] or <package>.<type>).
+    string file_containing_symbol = 4;
+
+    // Find the proto file which defines an extension extending the given
+    // message type with the given field number.
+    ExtensionRequest file_containing_extension = 5;
+
+    // Finds the tag numbers used by all known extensions of extendee_type, and
+    // appends them to ExtensionNumberResponse in an undefined order.
+    // Its corresponding method is best-effort: it's not guaranteed that the
+    // reflection service will implement this method, and it's not guaranteed
+    // that this method will provide all extensions. Returns
+    // StatusCode::UNIMPLEMENTED if it's not implemented.
+    // This field should be a fully-qualified type name. The format is
+    // <package>.<type>
+    string all_extension_numbers_of_type = 6;
+
+    // List the full names of registered services. The content will not be
+    // checked.
+    string list_services = 7;
+  }
+}
+
+// The type name and extension number sent by the client when requesting
+// file_containing_extension.
+message ExtensionRequest {
+  // Fully-qualified type name. The format should be <package>.<type>
+  string containing_type = 1;
+  int32 extension_number = 2;
+}
+
+// The message sent by the server to answer ServerReflectionInfo method.
+message ServerReflectionResponse {
+  string valid_host = 1;
+  ServerReflectionRequest original_request = 2;
+  // The server set one of the following fields according to the message_request
+  // in the request.
+  oneof message_response {
+    // This message is used to answer file_by_filename, file_containing_symbol,
+    // file_containing_extension requests with transitive dependencies. As
+    // the repeated label is not allowed in oneof fields, we use a
+    // FileDescriptorResponse message to encapsulate the repeated fields.
+    // The reflection service is allowed to avoid sending FileDescriptorProtos
+    // that were previously sent in response to earlier requests in the stream.
+    FileDescriptorResponse file_descriptor_response = 4;
+
+    // This message is used to answer all_extension_numbers_of_type request.
+    ExtensionNumberResponse all_extension_numbers_response = 5;
+
+    // This message is used to answer list_services request.
+    ListServiceResponse list_services_response = 6;
+
+    // This message is used when an error occurs.
+    ErrorResponse error_response = 7;
+  }
+}
+
+// Serialized FileDescriptorProto messages sent by the server answering
+// a file_by_filename, file_containing_symbol, or file_containing_extension
+// request.
+message FileDescriptorResponse {
+  // Serialized FileDescriptorProto messages. We avoid taking a dependency on
+  // descriptor.proto, which uses proto2 only features, by making them opaque
+  // bytes instead.
+  repeated bytes file_descriptor_proto = 1;
+}
+
+// A list of extension numbers sent by the server answering
+// all_extension_numbers_of_type request.
+message ExtensionNumberResponse {
+  // Full name of the base type, including the package name. The format
+  // is <package>.<type>
+  string base_type_name = 1;
+  repeated int32 extension_number = 2;
+}
+
+// A list of ServiceResponse sent by the server answering list_services request.
+message ListServiceResponse {
+  // The information of each service may be expanded in the future, so we use
+  // ServiceResponse message to encapsulate it.
+  repeated ServiceResponse service = 1;
+}
+
+// The information of a single service used by ListServiceResponse to answer
+// list_services request.
+message ServiceResponse {
+  // Full name of a registered service, including its package name. The format
+  // is <package>.<service>
+  string name = 1;
+}
+
+// The error code and error message sent by the server when an error occurs.
+message ErrorResponse {
+  // This field uses the error codes defined in grpc::StatusCode.
+  int32 error_code = 1;
+  string error_message = 2;
+}


### PR DESCRIPTION
Vendor the canonical grpc.health.v1 and grpc.reflection.v1alpha proto
definitions from https://github.com/grpc/grpc-proto/blob/master/
into the shared proto/ tree:

  proto/health/v1/health.proto         (3436 bytes)
  proto/reflection/v1alpha/reflection.proto (5836 bytes)

These are upstream verbatim (copyright headers + option metadata
preserved). The reflection.proto carries its upstream-deprecated
marker; v1alpha is the variant every mainstream gRPC language library
still ships as its public reflection package, so this is the right
shape for hello-grpc.

This PR is intentionally proto-only. It does not regenerate any
stubs, modify any hello-grpc-{lang}/ source, or add documentation.
Per-language code changes are queued behind this in follow-up PRs
(some real ones to consider right after this lands):

- hello-grpc-go:     RegisterHealthServer is already wired in
                     proto_server.go via health.NewServer; this
                     PR + a no-op regeneration unblocks production
                     parity.
- hello-grpc-java:   Wire io.grpc:grpc-services HealthServiceImpl +
                     ProtoReflectionService in ProtoServer.
- hello-grpc-cpp:    EnableDefaultHealthCheckService already wired
                     in proto_server.cpp (verified in cap audit);
                     EnableDefaultReflection needed for parity.
- hello-grpc-csharp: Register grpc.health and grpc.reflection services
                     (gRPC.HealthCheck and Grpc.AspNetCore.Reflection
                     packages).
- hello-grpc-kotlin: pull grpc-kotlin stub into server module
                     for health + reflection coverage.
- hello-grpc-python: pip install grpcio-health-checking +
                     grpcio-reflection, register in protoServer.py
                     (alongside the already-defined LoggingInterceptor
                     fix in #480).
- hello-grpc-nodejs: uncomment @grpc/grpc-js-reflection import
                     (the dep is already in package.json).
- hello-grpc-ts:     same as nodejs post-PR #480 path.
- hello-grpc-dart:   wait for grpc-dart to add first-class health /
                     reflection (currently no package surface).
- hello-grpc-rust:   tonic-health + tonic-reflection crates.
- hello-grpc-php:    extension level health is supported via
                     ServerCredentials::createSsl but the
                     language-level Php Health service surface
                     would need grpc/grpc-health-checking composer
                     package which is currently absent.
- hello-grpc-swift:  grpc-swift-health / grpc-swift-reflection
                     packages (separate repos, follow-ups if/when
                     the repo wants to be Swift parity complete).

A separate doc/grpc-services.md explaining what's now possible
with these proto files is a natural follow-up.