### PR TITLE
feat(nodejs): opt-in mTLS via GRPC_HELLO_REQUIRE_CLIENT_CERT

### DIFF
--- a/hello-grpc-nodejs/src/common/connection.js
+++ b/hello-grpc-nodejs/src/common/connection.js
@@ -87,24 +87,43 @@ function getClient() {
     if (secure === "Y") {
         try {
             logger.info("Connect With TLS to %s", address);
-            
+
             // Check if root certificate file exists
             if (!fs.existsSync(rootCert)) {
                 logger.error("Root certificate file not found: %s", rootCert);
                 throw new Error(`Root certificate file not found: ${rootCert}`);
             }
-            
+
             // Read root certificate
             const rootCertContent = fs.readFileSync(rootCert);
             logger.info("Loaded root certificate from: %s", rootCert);
-            logger.info("Using server-only TLS (no client certificate)");
-            
-            // Create TLS credentials without client certificates
-            const credentials = grpc.credentials.createSsl(
-                rootCertContent,
-                null,  // No client private key
-                null   // No client certificate
-            );
+
+            // When GRPC_HELLO_REQUIRE_CLIENT_CERT=Y is set, mirror server-side
+            // mTLS by attaching the client cert + key to the channel. Path is
+            // <certBasePath>/{cert.pem,private.key}. Default is one-way TLS
+            // (no client identity, matches the default on the server side).
+            const requireClientCert = process.env.GRPC_HELLO_REQUIRE_CLIENT_CERT === "Y";
+            const clientKeyPath = path.join(certPath, "private.key");
+            const clientCertPath = path.join(certPath, "cert.pem");
+            const hasClientKey = fs.existsSync(clientKeyPath);
+            const hasClientCert = fs.existsSync(clientCertPath);
+
+            let credentials;
+            if (requireClientCert && hasClientKey && hasClientCert) {
+                logger.info("Using mTLS (client certificate supplied)");
+                credentials = grpc.credentials.createSsl(
+                    rootCertContent,
+                    fs.readFileSync(clientKeyPath),
+                    fs.readFileSync(clientCertPath)
+                );
+            } else {
+                logger.info("Using server-only TLS (no client certificate)");
+                credentials = grpc.credentials.createSsl(
+                    rootCertContent,
+                    null,  // No client private key
+                    null   // No client certificate
+                );
+            }
             
             // Configure channel options
             const options = {

--- a/hello-grpc-nodejs/src/server/index.js
+++ b/hello-grpc-nodejs/src/server/index.js
@@ -176,14 +176,24 @@ function startSecureServer(server, address) {
 
         logger.info("Using certificate chain from: %s", fs.existsSync(certChainPath) ? certChainPath : certPath);
 
-        // Create TLS credentials - don't require client certificates (false)
+        // Create TLS credentials. The default is one-way TLS (server only);
+        // setting GRPC_HELLO_REQUIRE_CLIENT_CERT=Y switches to mutual TLS
+        // by requiring (and verifying, against the bundled client CA) a
+        // client-side cert on every connection.
+        const requireClientCert = process.env.GRPC_HELLO_REQUIRE_CLIENT_CERT === "Y";
+        const clientRootCert = requireClientCert
+            ? fs.readFileSync(path.join(
+                certBasePath.replace(/server_certs$/, "client_certs"),
+                "myssl_root.cer"
+            ))
+            : null;
         const credentials = grpc.ServerCredentials.createSsl(
-            null,  // Root certificates for client verification (null = don't verify client)
+            clientRootCert,  // root CAs for client-cert verification (null = no client auth)
             [{
                 cert_chain: certChainContent,
                 private_key: privateKeyContent
             }],
-            false // Don't require client certificate
+            requireClientCert
         );
 
         server.bindAsync(address, credentials, (err, port) => {


### PR DESCRIPTION
Closes the last async-language (Node.js / TypeScript) gap in the
mTLS capability line. Wired on both sides of the channel but kept
opt-in so existing ./server_start.sh and ./client_start.sh
behavior is unchanged.

Server (src/server/index.js startSecureServer): when
GRPC_HELLO_REQUIRE_CLIENT_CERT=Y, the bundled
<...>/client_certs/myssl_root.cer is loaded into the first
ServerCredentials.createSsl arg and the third arg flips to true.

Client (src/common/connection.js getClient): when the env var is
set, the client cert + key from client_certs/ are passed as the
third/fourth createSsl args (matching the server side).

Default-off because:
- Matches the existing opt-in pattern of GRPC_HELLO_SECURE=Y.
- Avoids breaking every hello-grpc-nodejs CI run that calls
  server_start without a real cert material.

Verified locally: npm test still 2 passing (the getVersion code
path doesn't touch TLS). The new branches only fire when the env
var is set, so non-mTLS runs are byte-identical to before this
commit at the channel-credential layer.

Cross-language backend tests (e.g. Node.js mTLS talking to Go's
RequireAndVerifyClientCert) deferred to a follow-up that brings
up startSecureServer with --mtls surface in start scripts.