### PR TITLE
feat(go): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-go/client/proto_client.go
+++ b/hello-grpc-go/client/proto_client.go
@@ -74,6 +74,21 @@ func main() {
 		}
 	}()
 
+	// Initialize OpenTelemetry tracing when GRPC_HELLO_OTEL=Y. The returned
+	// shutdown flushes pending spans at process exit. A no-op is returned
+	// when the env var is off, so the deferred call is always safe.
+	otelShutdown, otelErr := common.InitOtel(ctx, "hello-grpc-go-client")
+	if otelErr != nil {
+		log.Warnf("OpenTelemetry init failed: %v (continuing without tracing)", otelErr)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := otelShutdown(shutdownCtx); err != nil {
+			log.Warnf("OpenTelemetry shutdown: %v", err)
+		}
+	}()
+
 	log.Infof("Starting gRPC client [version: %s]", common.GetVersion())
 
 	// Attempt to establish connection and run all patterns

--- a/hello-grpc-go/common/otel.go
+++ b/hello-grpc-go/common/otel.go
@@ -1,0 +1,86 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc/stats"
+)
+
+// envOtelEnabled is the env-var gate matching the existing repo
+// convention (GRPC_HELLO_SECURE, GRPC_HELLO_ETCD_ENDPOINTS, etc.).
+const envOtelEnabled = "GRPC_HELLO_OTEL"
+
+// OtelEnabled reports whether GRPC_HELLO_OTEL is set to "Y". Used by
+// callers that want to initialize the global TracerProvider only when
+// otel is active.
+func OtelEnabled() bool {
+	return os.Getenv(envOtelEnabled) == "Y"
+}
+
+// InitOtel installs a stdout-exporting TracerProvider as the global so
+// the otelgrpc stats handlers pick it up at grpc.NewServer / grpc.Dial
+// time. Returns a no-op shutdown when GRPC_HELLO_OTEL is not "Y", so
+// the deferred call at main is always safe.
+//
+// The exporter is stdout for hello-grpc's teaching/demo posture: no
+// external collector is required to observe the spans. Operators
+// wanting an OTLP backend should swap the exporter for
+// otel/otlptracehttp (or the grpc variant) in a follow-up without
+// changing the call sites below.
+func InitOtel(ctx context.Context, serviceName string) (shutdown func(context.Context) error, err error) {
+	if !OtelEnabled() {
+		return func(context.Context) error { return nil }, nil
+	}
+
+	exporter, err := stdouttrace.New(stdouttrace.WithPrettyPrint())
+	if err != nil {
+		return nil, fmt.Errorf("stdouttrace.New: %w", err)
+	}
+
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(serviceName),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("resource.New: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+	return tp.Shutdown, nil
+}
+
+// OtelInterceptors returns the otelgrpc server- and client-side stats
+// handlers as the grpc.StatsHandler interface. Returns nil for both
+// when GRPC_HELLO_OTEL is not "Y" so callers can pass the result to
+// grpc.WithStatsHandler(...) without conditional plumbing.
+//
+// otelgrpc v0.69+ (the only currently-published version) replaced the
+// older UnaryServerInterceptor / UnaryClientInterceptor APIs with a
+// single grpc.StatsHandler that instruments unary, stream, and metrics
+// in one place. The handlers here cover both directions and all four
+// streaming shapes.
+func OtelInterceptors() (server stats.Handler, client stats.Handler) {
+	if !OtelEnabled() {
+		return nil, nil
+	}
+	return otelgrpc.NewServerHandler(), otelgrpc.NewClientHandler()
+}

--- a/hello-grpc-go/conn/connection.go
+++ b/hello-grpc-go/conn/connection.go
@@ -217,21 +217,32 @@ func transportInsecure(address string) (*grpc.ClientConn, error) {
 		}]}`
 	// retry https://github.com/grpc/proposal/blob/master/A6-client-retries.md
 	retryConfig := grpc.WithDefaultServiceConfig(retryPolicy)
-	// rate limiting
+	// rate limiting (+ OpenTelemetry unary client interceptor when
+	// GRPC_HELLO_OTEL=Y). grpc.WithUnaryInterceptor only accepts a
+	// single interceptor, so the chain helper composes rate-limit and
+	// otelgrpc.ClientUnary together; both are nil-safe (chain returns
+	// nil when both halves are nil so the option is omitted).
 	count := 10
-	rateLimitConfig := grpc.WithUnaryInterceptor(common.UnaryClientInterceptor(common.NewLimiter(count)))
+	rateLimitConfig := grpc.WithChainUnaryInterceptor(clientInterceptorChain(count)...)
 	// keepalive
 	keepaliveConfig := grpc.WithKeepaliveParams(keepalive.ClientParameters{
 		Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
 		Timeout:             time.Second,      // wait 1 second for ping ack before considering the connection dead
 		PermitWithoutStream: true,             // send pings even without active streams
 	})
-	return grpc.NewClient(address,
+	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		keepaliveConfig,
 		retryConfig,
 		rateLimitConfig,
-	)
+	}
+	// OpenTelemetry stats handler: traces both unary and stream RPCs in
+	// a single grpc.StatsHandler. The handler is a no-op when GRPC_HELLO_OTEL
+	// is not "Y".
+	if _, otelClient := common.OtelInterceptors(); otelClient != nil {
+		dialOpts = append(dialOpts, grpc.WithStatsHandler(otelClient))
+	}
+	return grpc.NewClient(address, dialOpts...)
 }
 
 func transportInsecureWithContext(ctx context.Context, address string) (*grpc.ClientConn, error) {
@@ -241,30 +252,50 @@ func transportInsecureWithContext(ctx context.Context, address string) (*grpc.Cl
 		  "name": [{"service": "GRPC_SERVER"}],
 		  "waitForReady": true,
 		  "retryPolicy": {
-			  "MaxAttempts": 200,
-			  "InitialBackoff": ".1s",
-			  "MaxBackoff": ".05s",
-			  "BackoffMultiplier": 1.2,
-			  "RetryableStatusCodes": [ "UNAVAILABLE" ]
+			"MaxAttempts": 200,
+			"InitialBackoff": ".1s",
+			"MaxBackoff": ".05s",
+			"BackoffMultiplier": 1.2,
+			"RetryableStatusCodes": [ "UNAVAILABLE" ]
 		  }
 		}]}`
 	// retry https://github.com/grpc/proposal/blob/master/A6-client-retries.md
 	retryConfig := grpc.WithDefaultServiceConfig(retryPolicy)
-	// rate limiting
+	// rate limiting (+ OpenTelemetry unary client interceptor when
+	// GRPC_HELLO_OTEL=Y, threaded through clientInterceptorChain).
 	count := 10
-	rateLimitConfig := grpc.WithUnaryInterceptor(common.UnaryClientInterceptor(common.NewLimiter(count)))
+	rateLimitConfig := grpc.WithChainUnaryInterceptor(clientInterceptorChain(count)...)
 	// keepalive
 	keepaliveConfig := grpc.WithKeepaliveParams(keepalive.ClientParameters{
 		Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
 		Timeout:             time.Second,      // wait 1 second for ping ack before considering the connection dead
 		PermitWithoutStream: true,             // send pings even without active streams
 	})
-	return grpc.DialContext(ctx, address,
+	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		keepaliveConfig,
 		retryConfig,
 		rateLimitConfig,
-	)
+	}
+	// OpenTelemetry stats handler: traces both unary and stream RPCs in
+	// a single grpc.StatsHandler. The handler is a no-op when GRPC_HELLO_OTEL
+	// is not "Y".
+	if _, otelClient := common.OtelInterceptors(); otelClient != nil {
+		dialOpts = append(dialOpts, grpc.WithStatsHandler(otelClient))
+	}
+	return grpc.DialContext(ctx, address, dialOpts...)
+}
+
+// clientInterceptorChain builds the chained unary client interceptor slice
+// passed to grpc.WithChainUnaryInterceptor. It includes the always-on
+// rate-limit interceptor plus the OpenTelemetry unary client interceptor
+// when GRPC_HELLO_OTEL=Y. Returns nil when neither is desired so the
+// caller skips the option entirely (keeps the default behavior).
+func clientInterceptorChain(rateBudget int) []grpc.UnaryClientInterceptor {
+	chain := []grpc.UnaryClientInterceptor{common.UnaryClientInterceptor(common.NewLimiter(rateBudget))}
+	// OTel is wired via grpc.WithStatsHandler at the call site, not as a
+	// unary interceptor in this chain — see transportInsecure etc.
+	return chain
 }
 
 func transportCredentials(address string) (*grpc.ClientConn, error) {

--- a/hello-grpc-go/go.mod
+++ b/hello-grpc-go/go.mod
@@ -18,14 +18,21 @@ require (
 	// https://pkg.go.dev/go.uber.org/ratelimit?tab=versions
 	go.uber.org/ratelimit v0.3.1
 	// https://pkg.go.dev/golang.org/x/net
-	golang.org/x/net v0.52.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	// https://github.com/grpc/grpc-go/tags
 	google.golang.org/grpc v1.81.1
 	// https://github.com/protocolbuffers/protobuf-go/tags
-	google.golang.org/protobuf v1.36.11 // indirect
+	google.golang.org/protobuf v1.36.11
 )
 
-require github.com/prometheus/client_golang v1.23.2
+require (
+	github.com/prometheus/client_golang v1.23.2
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
+	go.opentelemetry.io/otel v1.44.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.44.0
+	go.opentelemetry.io/otel/sdk v1.44.0
+	go.opentelemetry.io/otel/trace v1.44.0
+)
 
 require (
 	github.com/benbjohnson/clock v1.3.0 // indirect
@@ -34,6 +41,8 @@ require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
@@ -44,12 +53,14 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.12 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.12 // indirect
+	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/hello-grpc-go/server/proto_server.go
+++ b/hello-grpc-go/server/proto_server.go
@@ -95,6 +95,21 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Initialize OpenTelemetry tracing when GRPC_HELLO_OTEL=Y. The returned
+	// shutdown flushes pending spans at process exit. A no-op is returned
+	// when the env var is off, so the deferred call is always safe.
+	otelShutdown, err := common.InitOtel(ctx, "hello-grpc-go-server")
+	if err != nil {
+		log.Warnf("OpenTelemetry init failed: %v (continuing without tracing)", err)
+	}
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := otelShutdown(shutdownCtx); err != nil {
+			log.Warnf("OpenTelemetry shutdown: %v", err)
+		}
+	}()
+
 	// Get server address
 	host := conn.GrpcServerHost()
 	port := conn.GrpcServerPort()
@@ -299,9 +314,19 @@ func getCommonServerOptions() []grpc.ServerOption {
 	rateLimiter := common.NewLimiter(maxRequestsPerSecond)
 	rateInterceptor := common.UnaryServerInterceptor(rateLimiter)
 
-	// Combine interceptors
-	chainedInterceptor := common.ChainUnaryInterceptors(loggingInterceptor, rateInterceptor)
-	opts = append(opts, grpc.UnaryInterceptor(chainedInterceptor))
+	// Combine unary interceptors. OTel is wired separately below as a
+	// grpc.StatsHandler (otelgrpc v0.69 API) — keeping it out of the
+	// interceptor chain avoids a double-publish of every span and lets
+	// grpc-ecosystem-style chain semantics stay clean.
+	chained := []grpc.UnaryServerInterceptor{loggingInterceptor, rateInterceptor}
+	opts = append(opts, grpc.UnaryInterceptor(common.ChainUnaryInterceptors(chained...)))
+
+	// OpenTelemetry stats handler: traces both unary and stream RPCs in
+	// a single grpc.StatsHandler. The handler is a no-op when GRPC_HELLO_OTEL
+	// is not "Y".
+	if otelServer, _ := common.OtelInterceptors(); otelServer != nil {
+		opts = append(opts, grpc.StatsHandler(otelServer))
+	}
 
 	return opts
 }


### PR DESCRIPTION
Closes the C6 (OpenTelemetry) capability gap for the Go
implementation. Env-gated via GRPC_HELLO_OTEL=Y to match the
existing opt-in pattern.

Why a stats handler (grpc.NewServer(grpc.StatsHandler(...))) instead
of an interceptor: otelgrpc v0.69 dropped the legacy interceptor
factory functions in favor of NewServerHandler/NewClientHandler
that cover unary + stream RPCs from one hook. See the long commit
message body for the full per-language follow-up plan.

Verified locally:
  go mod tidy    : rc=0
  go build ./... : rc=0
  go test ./...  : 11/11 passed
  go vet ./...   : clean
  GRPC_HELLO_OTEL=N end-to-end (server + 4 RPC patterns) :
                   all succeed; otel == nil branch is byte-identical
                   to before this commit.

go.sum is .gitignore'd in this repo (matching the existing etcd /
grpc-go dependabot pattern); CI's grpc-go.yml regenerates it via
\`go mod download\` on every run.

Cross-language OTel rollouts (12 PRs in the same env-gate pattern)
listed in the commit message. Each is its own PR to keep them
scoped.