### PR TITLE
feat(java): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-java/pom.xml
+++ b/hello-grpc-java/pom.xml
@@ -37,6 +37,33 @@
             <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- gRPC OpenTelemetry interceptor (server + client):
+             io.grpc:grpc-opentelemetry is the grpc-java-bundled OTel
+             integration. Provides OpenTelemetryServerInterceptor /
+             OpenTelemetryClientInterceptor. -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-opentelemetry</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <!-- OpenTelemetry SDK + a logging exporter so spans show up
+             without needing a sidecar Jaeger / OTLP collector. Swap
+             in OtlpGrpcSpanExporter in OtelSupport.java for prod. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.43.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.43.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+            <version>1.43.0</version>
+        </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/client/ProtoClient.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/client/ProtoClient.java
@@ -423,8 +423,17 @@ public class ProtoClient {
    * @throws SSLException If SSL context setup fails
    */
   public void connect(ManagedChannel channel) throws SSLException {
-    ClientInterceptor interceptor = new HeaderClientInterceptor();
-    Channel interceptChannel = ClientInterceptors.intercept(channel, interceptor);
+    io.opentelemetry.api.OpenTelemetry clientOtel =
+        org.feuyeux.grpc.common.OtelSupport.initOtel("hello-grpc-java-client");
+    var chain = new java.util.ArrayList<io.grpc.ClientInterceptor>();
+    chain.add(new HeaderClientInterceptor());
+    var otelClient = org.feuyeux.grpc.common.OtelSupport.clientInterceptor(clientOtel);
+    if (otelClient != null) {
+      chain.add(otelClient);
+    }
+    Channel interceptChannel = ClientInterceptors.intercept(
+        channel,
+        chain.toArray(new io.grpc.ClientInterceptor[0]));
     blockingStub = LandingServiceGrpc.newBlockingStub(interceptChannel);
     asyncStub = LandingServiceGrpc.newStub(interceptChannel);
   }

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/common/OtelSupport.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/common/OtelSupport.java
@@ -1,0 +1,91 @@
+package org.feuyeux.grpc.common;
+
+import io.grpc.ClientInterceptor;
+import io.grpc.ServerInterceptor;
+import io.grpc.opentelemetry.GrpcOpenTelemetry;
+import io.grpc.opentelemetry.OpenTelemetryServerInterceptor;
+import io.grpc.opentelemetry.OpenTelemetryClientInterceptor;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.ResourceAttributes;
+
+/**
+ * OpenTelemetry wiring for hello-grpc-java.
+ *
+ * <p>Mirrors the Go implementation's design: an opt-in env var
+ * ({@code GRPC_HELLO_OTEL=Y}) installs a global {@link OpenTelemetry}
+ * provider and returns the grpc-java OTel interceptors; otherwise the
+ * factory methods return {@code null} so the call sites in
+ * {@code ProtoServer} and {@code ProtoClient} stay byte-identical
+ * to the pre-OTel paths.
+ *
+ * <p>The exporter is {@link LoggingSpanExporter} for the same teaching/
+ * demo posture as the Go side — operators wanting an OTLP backend
+ * swap it for {@code OtlpGrpcSpanExporter} here without changing
+ * anything else in the call graph.
+ */
+public final class OtelSupport {
+    public static final String ENV_OTEL_ENABLED = "GRPC_HELLO_OTEL";
+
+    private OtelSupport() {}
+
+    public static boolean otelEnabled() {
+        return "Y".equals(System.getenv(ENV_OTEL_ENABLED));
+    }
+
+    /**
+     * Install a logging-exporter-backed TracerProvider as the global
+     * OpenTelemetry SDK and return the same SDK so callers can pass it
+     * through to {@link GrpcOpenTelemetry}. Returns a no-op SDK (the
+     * default {@code OpenTelemetry#noop()}) when the env var is off,
+     * so the deferred call at main is always safe to make.
+     */
+    public static OpenTelemetry initOtel(String serviceName) {
+        if (!otelEnabled()) {
+            return OpenTelemetry.noop();
+        }
+        Resource resource = Resource.getDefault()
+                .merge(Resource.create(Attributes.of(
+                        ResourceAttributes.SERVICE_NAME, serviceName)));
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+                .setResource(resource)
+                .build();
+        return OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .build();
+    }
+
+    /**
+     * Returns the grpc-java {@link ServerInterceptor} for OTel tracing
+     * (or {@code null} if the env var is off). Caller chains it onto
+     * the service via {@code ServerInterceptors.intercept(...)}.
+     */
+    public static ServerInterceptor serverInterceptor(OpenTelemetry openTelemetry) {
+        if (!otelEnabled()) {
+            return null;
+        }
+        return OpenTelemetryServerInterceptor.create(new GrpcOpenTelemetry.Builder()
+                .sdk(openTelemetry)
+                .build());
+    }
+
+    /**
+     * Returns the grpc-java {@link ClientInterceptor} for OTel tracing
+     * (or {@code null} if the env var is off). Caller chains it via
+     * {@code ClientInterceptors.intercept(channel, ...)}.
+     */
+    public static ClientInterceptor clientInterceptor(OpenTelemetry openTelemetry) {
+        if (!otelEnabled()) {
+            return null;
+        }
+        return OpenTelemetryClientInterceptor.create(new GrpcOpenTelemetry.Builder()
+                .sdk(openTelemetry)
+                .build());
+    }
+}

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/server/ProtoServer.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/server/ProtoServer.java
@@ -21,12 +21,17 @@ import io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import org.feuyeux.grpc.client.HeaderClientInterceptor;
 import org.feuyeux.grpc.common.Connection;
 import org.feuyeux.grpc.proto.LandingServiceGrpc;
+import io.opentelemetry.api.OpenTelemetry;
+import io.grpc.opentelemetry.GrpcOpenTelemetry;
+import io.grpc.opentelemetry.OpenTelemetryServerInterceptor;
+import org.feuyeux.grpc.common.OtelSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +115,15 @@ public class ProtoServer {
    */
   public ProtoServer(LandingServiceImpl landingService)
       throws IOException, ExecutionException, InterruptedException {
-    this.server = createServer(landingService);
+    // Default constructor preserves pre-OTel behavior by passing a
+    // no-op SDK; createServer() consults OtelSupport.otelEnabled() for
+    // the interceptor factory.
+    this(landingService, OtelSupport.initOtel("hello-grpc-java-server"));
+  }
+
+  public ProtoServer(LandingServiceImpl landingService, OpenTelemetry otel)
+      throws IOException, ExecutionException, InterruptedException {
+    this.server = createServer(landingService, otel);
     start(landingService);
   }
 
@@ -123,12 +136,18 @@ public class ProtoServer {
       throws InterruptedException, IOException, ExecutionException {
     log.info("Starting gRPC server [version: {}]", getVersion());
 
+    // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. The returned
+    // SDK is no-op when the env var is off, so this call is always
+    // safe. The SDK handle is captured so the interceptor factory
+    // further down in createServer() can attach the same provider.
+    final OpenTelemetry otel = OtelSupport.initOtel("hello-grpc-java-server");
+
     try {
       // Initialize server implementation
       LandingServiceImpl landingService = createServiceImplementation();
 
       // Create and start server
-      ProtoServer server = new ProtoServer(landingService);
+      ProtoServer server = new ProtoServer(landingService, otel);
       log.info("Server started successfully");
 
       // Setup shutdown hook for graceful shutdown
@@ -197,9 +216,24 @@ public class ProtoServer {
    * @throws SSLException If TLS context setup fails
    */
   private Server createServer(LandingServiceImpl landingService) throws SSLException {
-    // Apply server interceptors to the service
+    return createServer(landingService, OtelSupport.initOtel("hello-grpc-java-server"));
+  }
+
+  private Server createServer(LandingServiceImpl landingService, OpenTelemetry otel)
+      throws SSLException {
+    // Apply server interceptors to the service. The OTel interceptor
+    // is null when GRPC_HELLO_OTEL is unset, so the chain is
+    // byte-identical to before this commit.
+    var chain = new ArrayList<io.grpc.ServerInterceptor>();
+    chain.add(new HeaderServerInterceptor());
+    var otelServer = OtelSupport.serverInterceptor(otel);
+    if (otelServer != null) {
+      chain.add(otelServer);
+    }
     ServerServiceDefinition interceptedService =
-        ServerInterceptors.intercept(landingService, new HeaderServerInterceptor());
+        ServerInterceptors.intercept(
+            landingService,
+            chain.toArray(new io.grpc.ServerInterceptor[0]));
 
     // Determine if secure mode is enabled
     String secureMode = System.getenv(GRPC_HELLO_SECURE);


### PR DESCRIPTION
Closes the C6 OpenTelemetry capability gap for the Java
implementation. Uses io.grpc:grpc-opentelemetry (the grpc-java
bundled interceptor module) with the standard SDK + a logging
exporter. Same env-gate pattern as PR #486's Go implementation.

Default behavior is byte-identical when GRPC_HELLO_OTEL is unset.

Not locally built — Windows runner lacks the JDK + Maven combo that
CI uses. CI's grpc-java-kotlin.yml is the source of truth for the
build.

Follow-ups queued in the same env-gate pattern:
  hello-grpc-python   : opentelemetry-instrumentation-grpc + extras[]
  hello-grpc-nodejs/.ts : @opentelemetry/instrumentation-grpc
  hello-grpc-kotlin    : reuses grpc-java's otel module
  hello-grpc-rust      : tracing-opentelemetry via tonic's tracing
  hello-grpc-csharp    : OpenTelemetry.Instrumentation.GrpcNetClient
  hello-grpc-c++       : grpc::experimental::OtelServerInterceptor
  hello-grpc-swift     : GRPCSwiftTracing + TracingHook protocol