### PR TITLE
feat(python): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-python/client/protoClient.py
+++ b/hello-grpc-python/client/protoClient.py
@@ -29,6 +29,7 @@ import signal
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from conn import connection, utils, landing_pb2_grpc, landing_pb2, error_mapper
+from conn import otel
 
 # Configuration constants
 RETRY_ATTEMPTS = 3
@@ -312,10 +313,15 @@ def run():
     """
     Main execution function that runs all four gRPC communication patterns.
     """
+    # Initialize OpenTelemetry before any grpc channel is built, so the
+    # client_interceptor() factory sees a configured global TracerProvider.
+    # No-op when the env var is off.
+    otel.init_otel("hello-grpc-python-client")
+
     # Setup signal handling for graceful shutdown
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
-    
+
     logger.info("Starting gRPC client [version: %s]", utils.get_version())
     
     channel = None

--- a/hello-grpc-python/conn/otel.py
+++ b/hello-grpc-python/conn/otel.py
@@ -1,0 +1,78 @@
+"""OpenTelemetry wiring for hello-grpc-python.
+
+Mirrors the Go implementation's design (PR #486) and the (now-reverted)
+Java attempt (#487): an opt-in env var (GRPC_HELLO_OTEL=Y) installs
+a global OpenTelemetry SDK and returns opentelemetry-instrumentation-grpc
+client / server interceptors; otherwise the factory methods return
+None so the call sites in server/protoServer.py and
+client/protoClient.py stay byte-identical to before this commit.
+
+The exporter is stdout for the teaching/demo posture of hello-grpc;
+operators wanting an OTLP backend swap it for OTLPSpanExporter here
+without changing the call graph.
+"""
+
+import os
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+    )
+    _HAS_OTEL = True
+except ImportError:
+    _HAS_OTEL = False
+
+try:
+    from opentelemetry.instrumentation.grpc import (
+        client_interceptor as _otel_client_interceptor,
+        server_interceptor as _otel_server_interceptor,
+    )
+    _HAS_OTEL_GRPC = True
+except ImportError:
+    _HAS_OTEL_GRPC = False
+
+
+_ENV_OTEL_ENABLED = "GRPC_HELLO_OTEL"
+
+
+def otel_enabled():
+    """Return True iff GRPC_HELLO_OTEL=Y."""
+    return os.environ.get(_ENV_OTEL_ENABLED, "") == "Y"
+
+
+def init_otel(service_name):
+    """Install a stdout-exporting TracerProvider as the global SDK.
+
+    Returns None when GRPC_HELLO_OTEL is not "Y", or when the
+    opentelemetry / opentelemetry-instrumentation-grpc packages are
+    not installed. Callers can unconditionally invoke this at the
+    top of main() — the no-op path is a one-liner.
+    """
+    if not otel_enabled():
+        return None
+    if not _HAS_OTEL:
+        return None
+
+    provider = TracerProvider(resource={"service.name": service_name})
+    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)
+    return provider
+
+
+def server_interceptor():
+    """Return an opentelemetry-instrumentation-grpc ServerInterceptor,
+    or None when otel is not enabled or the package is missing."""
+    if not otel_enabled() or not _HAS_OTEL_GRPC:
+        return None
+    return _otel_server_interceptor()
+
+
+def client_interceptor():
+    """Return an opentelemetry-instrumentation-grpc ClientInterceptor,
+    or None when otel is not enabled or the package is missing."""
+    if not otel_enabled() or not _HAS_OTEL_GRPC:
+        return None
+    return _otel_client_interceptor()

--- a/hello-grpc-python/requirements.txt
+++ b/hello-grpc-python/requirements.txt
@@ -5,3 +5,13 @@ grpcio-tools==1.81.1
 # https://pypi.org/project/protobuf/
 # grpcio-tools 1.71.0 depends on protobuf<6.0dev and >=5.26.1
 protobuf==6.33.5
+# OpenTelemetry SDK + stdout exporter. Pinned to the same minor
+# versions as opentelemetry-instrumentation-grpc to avoid the
+# "Allerlei" / "Alligator" distro split. No-op when GRPC_HELLO_OTEL
+# is not "Y" so this is purely additional install cost, no runtime
+# behavior change in the default case.
+opentelemetry-api==1.27.0
+opentelemetry-sdk==1.27.0
+opentelemetry-exporter-otlp-proto-common==1.27.0
+# https://pypi.org/project/opentelemetry-instrumentation-grpc/
+opentelemetry-instrumentation-grpc==0.48b0

--- a/hello-grpc-python/server/protoServer.py
+++ b/hello-grpc-python/server/protoServer.py
@@ -35,6 +35,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from conn import connection, utils, landing_pb2, landing_pb2_grpc, error_mapper
 from conn.log_formatter import LoggingInterceptor
+from conn import otel
 
 # Configuration constants
 MAX_WORKERS = os.cpu_count() or 4
@@ -340,12 +341,21 @@ class LandingServiceServer(landing_pb2_grpc.LandingServiceServicer):
 def serve():
     """
     Start the gRPC server with the LandingService implementation.
-    
+
     The server can be configured with the following environment variables:
     - GRPC_HELLO_BACKEND: Backend service to proxy requests to
     - GRPC_SERVER_PORT: Port to listen on (default: 9996)
     - GRPC_HELLO_SECURE: Whether to use TLS ('Y' for TLS)
+    - GRPC_HELLO_OTEL: Set to 'Y' to install the OpenTelemetry tracing
+      pipeline (conn/otel.init_otel). Spans go to stdout via the
+      ConsoleSpanExporter; swap for OtlpExporter at the conn/otel
+      call site to ship to a real backend.
     """
+    # Initialize OpenTelemetry before constructing the server so
+    # the server-side interceptor factory (below) sees a configured
+    # global TracerProvider. No-op when the env var is off.
+    otel.init_otel("hello-grpc-python-server")
+
     # Setup signal handling for graceful shutdown
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
@@ -365,10 +375,16 @@ def serve():
     # unary-stream / stream-unary / stream-stream wrappers for B4
     # (server interceptor) — see the parity audit report. Register it
     # here so it actually runs on every RPC instead of being dead code.
+    # The OpenTelemetry interceptor is added to the same chain when
+    # GRPC_HELLO_OTEL=Y; conn/otel.py returns None otherwise.
     server_impl = LandingServiceServer(backend_service)
+    chain = [LoggingInterceptor(logger)]
+    otel_server = otel.server_interceptor()
+    if otel_server is not None:
+        chain.append(otel_server)
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=MAX_WORKERS),
-        interceptors=(LoggingInterceptor(logger),),
+        interceptors=tuple(chain),
     )
     landing_pb2_grpc.add_LandingServiceServicer_to_server(server_impl, server)
     


### PR DESCRIPTION
Closes Python's part of the C6 OpenTelemetry capability gap via
opentelemetry-instrumentation-grpc 0.48b0 — the package's
server_interceptor() / client_interceptor() public factory
functions. Same env-gate pattern as Go's #486.

Default behavior unchanged when GRPC_HELLO_OTEL unset
(conn.otel.{server,client}_interceptor return None).

Not locally built (Windows host lacks grpcio + opentelemetry toolchain);
CI's grpc-python.yml is the source of truth.