### PR TITLE
feat(rust): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-rust/Cargo.toml
+++ b/hello-grpc-rust/Cargo.toml
@@ -56,8 +56,14 @@ hyper = { version = "1.5.2", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 # tracing https://lib.rs/crates/tracing
 tracing = "0.1"
-# tracing subscriber https://lib.rs/crates/tracing-subscriber
+# https://lib.rs/crates/tracing-subscriber
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# OpenTelemetry SDK + stdout exporter. Pinned to the 0.27 line that
+# matches tracing-opentelemetry 0.28's documented compat matrix.
+opentelemetry = { version = "0.27", features = ["trace"] }
+opentelemetry-stdout = { version = "0.27", features = ["trace"] }
+opentelemetry-semantic-conventions = "0.27"
+tracing-opentelemetry = "0.28"
 # rustls with ring crypto provider for TLS
 rustls = { version = "0.23", features = ["ring"] }
 

--- a/hello-grpc-rust/src/landing/client.rs
+++ b/hello-grpc-rust/src/landing/client.rs
@@ -37,7 +37,10 @@ const DEFAULT_BATCH_SIZE: usize = 5;
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize rustls crypto provider
     let _ = rustls::crypto::ring::default_provider().install_default();
-    
+
+    // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. No-op otherwise.
+    crate::otel::init_otel("hello-grpc-rust-client");
+
     // Initialize logging
     log4rs::init_file(CONFIG_PATH, Default::default())?;
     

--- a/hello-grpc-rust/src/landing/server.rs
+++ b/hello-grpc-rust/src/landing/server.rs
@@ -86,6 +86,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize rustls crypto provider
     let _ = rustls::crypto::ring::default_provider().install_default();
 
+    // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. No-op when the
+    // env var is unset so the existing log4rs + tonic/tracing pipeline
+    // is preserved by default.
+    crate::otel::init_otel("hello-grpc-rust-server");
+
     // Initialize logging
     log4rs::init_file(CONFIG_PATH, Default::default())?;
 

--- a/hello-grpc-rust/src/lib.rs
+++ b/hello-grpc-rust/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod common;
+pub mod landing;
+pub mod otel;

--- a/hello-grpc-rust/src/otel.rs
+++ b/hello-grpc-rust/src/otel.rs
@@ -1,0 +1,49 @@
+//! hello-grpc-rust OpenTelemetry wiring.
+//!
+//! Mirrors the Go (#486), Python (#488), and Node.js/TS (#489) gates.
+//! opt-in via `GRPC_HELLO_OTEL=Y`. When unset, `init_otel` is a no-op
+//! and tonic's existing `tracing` instrumentation is untouched.
+//!
+//! The exporter is stdout (`opentelemetry-stdout`) so spans show up
+//! without a sidecar Jaeger / OTLP collector. Operators wanting an
+//! OTLP backend swap in `opentelemetry-otlp` here without changing
+//! the call sites in server.rs / client.rs.
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::{SdkTracerProvider, Sampler};
+use opentelemetry_sdk::Resource;
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+/// Returns true iff `GRPC_HELLO_OTEL=Y`.
+pub fn otel_enabled() -> bool {
+    std::env::var("GRPC_HELLO_OTEL").map(|v| v == "Y").unwrap_or(false)
+}
+
+/// One-time OTel SDK + tracing-subscriber wiring. Idempotent: a second
+/// call (e.g. when invoked from both server and client mains) returns
+/// without making further changes.
+pub fn init_otel(service_name: &'static str) {
+    if !otel_enabled() {
+        return;
+    }
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let exporter = opentelemetry_stdout::SpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_resource(Resource::builder().with_attribute(
+                opentelemetry::KeyValue::new(SERVICE_NAME, service_name),
+            ).build())
+            .with_sampler(Sampler::AlwaysOn)
+            .with_simple_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("hello-grpc-rust");
+        // Bridge tonic's tracing -> OTel spans. Without this layer,
+        // tonic emits tracing events but they go nowhere.
+        let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        tracing_subscriber::registry()
+            .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+            .with(layer)
+            .init();
+    });
+}


### PR DESCRIPTION
Wires tracing-opentelemetry 0.28 + opentelemetry 0.27 over tonic. Same env-gate pattern. Default behavior unchanged when GRPC_HELLO_OTEL unset.