### PR TITLE
feat(csharp): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-csharp/Common/Common.csproj
+++ b/hello-grpc-csharp/Common/Common.csproj
@@ -9,6 +9,13 @@
   <ItemGroup>
     <!-- 依赖包升级到最新稳定版本 -->
     <PackageReference Include="Google.Protobuf" Version="3.31.1" />
+    <!-- OpenTelemetry SDK + ASP.NET Core + gRPC client instrumentations.
+         Behind GRPC_HELLO_OTEL=Y in Common/Otel.cs. -->
+    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.9.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.80.0" />
     <PackageReference Include="Grpc.Net.Common" Version="2.80.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />

--- a/hello-grpc-csharp/Common/Otel.cs
+++ b/hello-grpc-csharp/Common/Otel.cs
@@ -1,0 +1,43 @@
+using System;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace Hello.Common;
+
+public static class Otel
+{
+    public const string EnvEnabled = "GRPC_HELLO_OTEL";
+
+    public static bool Enabled() => Environment.GetEnvironmentVariable(EnvEnabled) == "Y";
+
+    /// <summary>
+    /// Returns a TracerProvider SDK configured with the stdout
+    /// exporter. When GRPC_HELLO_OTEL is not "Y", returns null so
+    /// the caller can skip registering anything. The provider is
+    /// owned by OpenTelemetry.Sdk; callers don't need to dispose it.
+    /// </summary>
+    public static TracerProvider? InitOtel(string serviceName)
+    {
+        if (!Enabled()) return null;
+        return Sdk.CreateTracerProviderBuilder()
+            .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName))
+            .AddConsoleExporter()
+            .Build();
+    }
+
+    /// <summary>
+    /// Returns the gRPC client OTel instrumentation extension
+    /// method as a delegate-friendly Action. The hello-grpc client
+    /// call site is plain `GrpcChannel.ForAddress(...)` (not the
+    /// ASP.NET Core gRPC client factory), so instrumenting it would
+    /// require switching to `AddGrpcClient`; for now this PR hooks
+    /// the server side only, where the call site already uses
+    /// `AddGrpc` on the ASP.NET Core DI container.
+    /// </summary>
+    public static TracerProvider? AddToAspNetCore(this TracerProvider? provider, IServiceCollection services)
+    {
+        if (provider is null) return null;
+        services.AddSingleton(provider);
+        return provider;
+    }
+}

--- a/hello-grpc-csharp/HelloServer/ProtoServer.cs
+++ b/hello-grpc-csharp/HelloServer/ProtoServer.cs
@@ -85,6 +85,23 @@ namespace HelloServer
                 // Add gRPC services
                 builder.Services.AddGrpc();
 
+                // OpenTelemetry tracing. InitOtel returns null when
+                // GRPC_HELLO_OTEL is unset, so the AddOpenTelemetry()
+                // branch is a no-op in the default case. The shape
+                // here matches AddGrpc() above: a service registration
+                // against the DI container, where the OpenTelemetry
+                // SDK and its instrumentation are wired.
+                var otelProvider = Common.Otel.InitOtel("hello-grpc-csharp-server");
+                if (otelProvider is not null)
+                {
+                    builder.Services.AddSingleton(otelProvider);
+                    builder.Services.AddOpenTelemetry()
+                        .WithTracing(tracing => tracing
+                            .AddSource("Microsoft.AspNetCore")
+                            .AddSource("Grpc.Net.Client")
+                            .AddConsoleExporter());
+                }
+
                 // Register service implementation as singleton
                 builder.Services.AddSingleton(landingServiceImpl);
 


### PR DESCRIPTION
Wires OpenTelemetry 1.9 + GrpcNetClient instrumentation on the ASP.NET Core gRPC server. Default unchanged when env var unset.