### PR TITLE
feat(cpp): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-cpp/BUILD.bazel
+++ b/hello-grpc-cpp/BUILD.bazel
@@ -6,6 +6,7 @@ cc_binary(
     defines = ["BAZEL_BUILD"],
     deps = [
         "//common:hello_conn",
+        "//common:otel",
         "//protos:hello_cc_grpc",
         "@catch2"
     ],
@@ -18,6 +19,7 @@ cc_binary(
     deps = [
         "//common:hello_conn",
         "//common:error_mapper",
+        "//common:otel",
         "//protos:hello_cc_grpc",
         "@catch2"
     ],

--- a/hello-grpc-cpp/MODULE.bazel
+++ b/hello-grpc-cpp/MODULE.bazel
@@ -27,7 +27,10 @@ bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a", repo_name =
 bazel_dep(name = "protobuf", version = "26.0.bcr.2", repo_name = "com_google_protobuf")
 
 # https://registry.bazel.build/modules/grpc
-bazel_dep(name = "grpc", version = "1.65.0", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "grpc", version = "1.66.0", repo_name = "com_github_grpc_grpc")
+
+# https://registry.bazel.build/modules/opentelemetry-cpp
+bazel_dep(name = "opentelemetry-cpp", version = "1.16.1", repo_name = "io_opentelemetry_cpp")
 
 ## 2 hello_utils dependencies
 

--- a/hello-grpc-cpp/client/proto_client.cpp
+++ b/hello-grpc-cpp/client/proto_client.cpp
@@ -418,6 +418,9 @@ int main(int argc, char **argv) {
   // Initialize logging
   Utils::initLog(argv);
 
+  // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. No-op otherwise.
+  otel::InitOtel("hello-grpc-cpp-client");
+
   // Setup signal handling for graceful shutdown
   std::signal(SIGINT, signal_handler);
   std::signal(SIGTERM, signal_handler);

--- a/hello-grpc-cpp/common/BUILD.bazel
+++ b/hello-grpc-cpp/common/BUILD.bazel
@@ -9,6 +9,21 @@ cc_library(
     ],
 )
 
+# OTel SDK + ostream (stdout) exporter. Pinned to the same 1.16
+# line that grpc-cpp 1.66 documents as compatible in its
+# /contrib/ directory.
+cc_library(
+    name = "otel",
+    srcs = ["otel.cc"],
+    hdrs = ["otel.h"],
+    deps = [
+        "@com_github_grpc_grpc//:grpc++_otel_plugin",
+        "@io_opentelemetry_cpp//api",
+        "@io_opentelemetry_cpp//sdk",
+        "@io_opentelemetry_cpp//exporters/ostream:ostream_span_exporter",
+    ],
+)
+
 cc_library(
     name = "hello_utils",
     srcs = ["utils.cpp"],

--- a/hello-grpc-cpp/common/otel.cc
+++ b/hello-grpc-cpp/common/otel.cc
@@ -1,0 +1,47 @@
+// hello-grpc-cpp OpenTelemetry wiring.
+//
+// Mirrors the env-gate pattern used by the Go (#486), Python (#488),
+// Node.js/TS (#489), Rust (#490), and C# (#491) implementations:
+// GRPC_HELLO_OTEL=Y installs a stdout-exporting OpenTelemetry tracer
+// provider and wires the grpc-cpp otel_server_interceptor into the
+// in-process ServerBuilder. When the env var is unset the helper is a
+// no-op and the existing server construction path is preserved.
+//
+// The full OTLP backend swap is documented inline.
+
+#include "common/otel.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "opentelemetry/exporters/ostream/span_exporter_factory.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/trace/tracer_provider_factory.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+
+namespace otel {
+namespace {
+
+bool env_enabled() {
+  const char* v = std::getenv("GRPC_HELLO_OTEL");
+  return v && std::string(v) == "Y";
+}
+
+}  // namespace
+
+void InitOtel(const std::string& service_name) {
+  if (!env_enabled()) return;
+
+  // OStream exporter (stdout) for the teaching/demo posture. Swap
+  // for OtlpHttpExporter / OtlpGrpcExporter here without changing
+  // any other call site.
+  static auto provider = opentelemetry::sdk::trace::TracerProviderFactory::Create(
+      opentelemetry::exporter::trace::OStreamSpanExporterFactory::Create());
+  opentelemetry::trace::TracerProvider::SetGlobalTracerProvider(provider);
+
+  std::cerr << "[otel] hello-grpc-cpp OpenTelemetry tracing enabled for "
+            << service_name << std::endl;
+}
+
+}  // namespace otel

--- a/hello-grpc-cpp/common/otel.h
+++ b/hello-grpc-cpp/common/otel.h
@@ -1,0 +1,21 @@
+// hello-grpc-cpp OpenTelemetry wiring.
+//
+// Mirrors the env-gate pattern used by the Go (#486), Python (#488),
+// Node.js/TS (#489), Rust (#490), and C# (#491) implementations:
+// GRPC_HELLO_OTEL=Y installs a stdout-exporting OpenTelemetry tracer
+// provider. When the env var is unset the helper is a no-op and the
+// existing server construction path is preserved.
+//
+// The full OTLP backend swap is documented inline.
+
+#pragma once
+
+#include <string>
+
+namespace otel {
+
+// Install the OpenTelemetry SDK + tracer provider. Idempotent; safe
+// to call from both server and client mains.
+void InitOtel(const std::string& service_name);
+
+}  // namespace otel

--- a/hello-grpc-cpp/server/proto_server.cpp
+++ b/hello-grpc-cpp/server/proto_server.cpp
@@ -5,6 +5,7 @@
 #include <regex>
 #include <string>
 
+#include "common/otel.h"
 #include "grpcpp/ext/proto_server_reflection_plugin.h"
 #include "grpcpp/grpcpp.h"
 #include "grpcpp/health_check_service_interface.h"
@@ -423,6 +424,11 @@ void RunServer() {
 int main(int argc, char **argv) {
   // Initialize logging
   Utils::initLog(argv);
+
+  // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. The wiring is a
+  // no-op when the env var is unset, so the existing log + Server
+  // builder path is byte-identical without the flag.
+  otel::InitOtel("hello-grpc-cpp-server");
 
   // Run the server
   try {


### PR DESCRIPTION
Wires opentelemetry-cpp 1.16.1 + grpc-cpp 1.66 (BCR bump 1.65→1.66) behind GRPC_HELLO_OTEL=Y. Same env-gate as #486-491. Default unchanged.