### PR TITLE
feat(php): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-php/common/utils/Otel.php
+++ b/hello-grpc-php/common/utils/Otel.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Utils;
+
+/**
+ * hello-grpc-php OpenTelemetry wiring.
+ *
+ * Mirrors the env-gate pattern used by the prior OTel PRs in this
+ * repository: read GRPC_HELLO_OTEL, install an OpenTelemetry SDK +
+ * tracer provider when it is "Y", otherwise stay a no-op.
+ *
+ * Note on PHP gRPC interceptor support
+ * -----------------------------------
+ * The grpc PHP extension does not currently expose interceptor
+ * callbacks at the ServerBuilder / Channel construction level
+ * (c-extension gRPC server API takes service handlers, not
+ * interceptor chains). That means gRPC per-call spans cannot be
+ * emitted from PHP without either: (a) a future gRPC PHP extension
+ * change, (b) running grpcphp / grpcio on top of the underlying PHP
+ * extension and instrumenting at that layer, or (c) running
+ * post-response hooks via the noop-on-success + exception-based
+ * filter that wraps each handler in user code.
+ *
+ * Approach (c) is what `Otel::initOtel` enables here: the SDK + a
+ * tracer are installed so that handler-side `tracer->spanBuilder()`
+ * calls work today; the per-gRPC-call wiring will be added in a
+ * follow-up PR that touches hello_server.php /
+ * LandingServiceImpl.php to wrap each handler.
+ */
+final class Otel
+{
+    public const ENV_ENABLED = 'GRPC_HELLO_OTEL';
+
+    /** Cached tracer provider to avoid double-init. */
+    private static $tracerProvider = null;
+
+    public static function enabled(): bool
+    {
+        return getenv(self::ENV_ENABLED) === 'Y';
+    }
+
+    /**
+     * Returns a no-op TracerProvider when env var is unset, or the
+     * configured exporter-backed one when set. Idempotent.
+     */
+    public static function initOtel(string $serviceName)
+    {
+        if (!self::enabled()) {
+            // No-op provider. Returning the interface symbol a real
+            // consumer might resolve is overkill — the call sites
+            // currently gate on `enabled()` themselves.
+            return null;
+        }
+        if (self::$tracerProvider !== null) {
+            return self::$tracerProvider;
+        }
+        // The SDK lives across the bundled open-telemetry/sdk +
+        // open-telemetry/exporter-otlp packages, both of which this
+        // PR's composer.json addition pulls. Operator swap from
+        // OTLP to stdout here is a single line.
+        $tracerProvider = \OpenTelemetry\SDK\Trace\TracerProvider::builder()
+            ->addSpanProcessor(
+                (new \OpenTelemetry\Contrib\Otlp\SpanExporter(\OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory::create(
+                    $_ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] ?? 'http://localhost:4318',
+                    'application/x-protobuf'
+                )))->getSpanExporter()
+            )
+            ->setResource(\OpenTelemetry\SDK\Resource\ResourceInfoFactory::defaultResource()->merge(
+                \OpenTelemetry\SDK\Resource\ResourceInfoFactory::emptyResource()->withAttributes(
+                    \OpenTelemetry\SDK\Common\Attribute::factory()
+                        ->key('service.name')
+                        ->string($serviceName)
+                        ->build()
+                )
+            ))
+            ->build();
+        self::$tracerProvider = $tracerProvider;
+        return $tracerProvider;
+    }
+}

--- a/hello-grpc-php/composer.json
+++ b/hello-grpc-php/composer.json
@@ -5,7 +5,10 @@
         "grpc/grpc": "^1.74.0",
         "google/protobuf": "^v4.0.0",
         "ramsey/uuid": "^4.7.5",
-        "monolog/monolog": "^3.5.0"
+        "monolog/monolog": "^3.5.0",
+        "open-telemetry/api": "^1.9",
+        "open-telemetry/sdk": "^1.14",
+        "open-telemetry/exporter-otlp": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/hello-grpc-php/hello_client.php
+++ b/hello-grpc-php/hello_client.php
@@ -12,6 +12,7 @@ use Monolog\Formatter\LineFormatter;
 
 require dirname(__FILE__) . '/vendor/autoload.php';
 require dirname(__FILE__) . '/conn/Connection.php';
+require dirname(__FILE__) . '/common/utils/Otel.php';
 
 // Constants for configuration
 const MAX_RETRIES = 3;
@@ -19,6 +20,14 @@ const BASE_BACKOFF_MS = 500;
 const STREAM_TIMEOUT_MS = 10000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 5000;
 const BIDIRECTIONAL_READ_TIMEOUT_MS = 100;
+
+// Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. The PHP C
+// extension does not currently expose interceptor callbacks at the
+// per-gRPC-call level (RpcServer takes service handlers directly,
+// without an interceptor chain), so the wiring is partial in this
+// PR: the SDK + exporter are installed so future handler-side span
+// calls have a configured Tracer to use.
+Otel::initOtel("hello-grpc-php-client");
 
 // Create logger
 $log = new Logger('HelloClient');

--- a/hello-grpc-php/hello_server.php
+++ b/hello-grpc-php/hello_server.php
@@ -15,6 +15,7 @@ use Monolog\Handler\StreamHandler;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Formatter\LineFormatter;
 use Common\Utils\VersionUtils;
+use Common\Utils\Otel;
 
 // Include required files
 require dirname(__FILE__) . '/vendor/autoload.php';
@@ -100,7 +101,17 @@ function getVersion(): string {
 
 try {
     $log->info("Initializing gRPC server");
-    
+
+    // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. Returns null
+    // when the env var is unset; a follow-up PR will wrap each
+    // service handler in hello_server.php / LandingServiceImpl.php
+    // with a tracer->spanBuilder() call so per-gRPC-call spans get
+    // emitted. The C extension's grpc RpcServer does not currently
+    // expose an interceptor slot, so the wiring is partial in this
+    // PR; OTel::initOtel just installs the SDK + exporter so future
+    // handler-side spans have a configured Tracer to use.
+    Otel::initOtel("hello-grpc-php-server");
+
     // Initialize connection configuration
     $conn = new Connection();
     


### PR DESCRIPTION
Wires OpenTelemetry PHP SDK + OTLP HTTP exporter so a Tracer is configured for env-gated use. Known limitation carried in Otel.php docstring: the PHP ext-grpc does not expose interceptor slots, so per-gRPC-call span wiring requires a follow-up that wraps each handler in hello_server.php.