### PR TITLE
feat(dart): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-dart/lib/client.dart
+++ b/hello-grpc-dart/lib/client.dart
@@ -18,6 +18,7 @@ import 'package:logging/logging.dart';
 
 import 'common/common.dart';
 import 'common/landing.pbgrpc.dart';
+import 'common/otel.dart';
 import 'conn/conn.dart';
 
 // Configuration constants
@@ -38,6 +39,11 @@ class Client {
 
   /// Main entry point for the client
   Future<void> main(List<String> args) async {
+    // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. Awaiting
+    // here is cheap (in-memory provider setup) and the SDK is then
+    // available for any handler-side span emission added later.
+    await initOtel('hello-grpc-dart-client');
+
     _configureLogging();
     _logger = Logger('HelloClient');
     _setupSignalHandling();

--- a/hello-grpc-dart/lib/common/otel.dart
+++ b/hello-grpc-dart/lib/common/otel.dart
@@ -1,0 +1,50 @@
+// ignore_for_file: avoid_print
+import 'dart:async';
+import 'dart:io';
+
+import 'package:opentelemetry_dart/opentelemetry_dart.dart';
+
+/// hello-grpc-dart OpenTelemetry wiring.
+///
+/// Mirrors the env-gate pattern in the prior OTel PRs across the
+/// other languages. opt-in via `GRPC_HELLO_OTEL=Y`.
+///
+/// Caveat: grpc-dart does not yet ship an OpenTelemetry client/
+/// server interceptor at the time of writing, so this module
+/// exposes a minimal tracer that future interceptor code can be
+/// built around. The env var also installs a tracer provider so
+/// that any in-process tracer usage (service handlers, custom
+/// async spans) works against a configured global tracer. The
+/// interceptor half follows in a follow-up PR.
+
+bool _enabled = false;
+bool _initialized = false;
+
+bool otelEnabled() {
+  if (_enabled) return true;
+  final v = Platform.environment['GRPC_HELLO_OTEL'];
+  _enabled = v == 'Y';
+  return _enabled;
+}
+
+/// One-time TracerProvider + tracer install for the calling
+/// process. Idempotent. No-op when otel is not enabled.
+Future<void> initOtel(String serviceName) async {
+  if (!otelEnabled() || _initialized) return;
+  _initialized = true;
+
+  // Process-level resource. The default global propagator + exporter
+  // wiring is provided by package:opentelemetry_dart; stdout is the
+  // teaching/demo posture across the other languages.
+  final resource = OTelResource(
+    serviceName: serviceName,
+    serviceVersion: '0.1.0',
+  );
+  final exporter = OTelConsoleExporter();
+  final provider = OTelTracerProvider(resource: resource, exporter: exporter);
+  OTelTrace.register(provider, setAsGlobal: true);
+
+  // Print to stdout so the user can see wiring took effect.
+  // ignore: avoid_print
+  print('[otel] hello-grpc-dart tracing enabled for $serviceName');
+}

--- a/hello-grpc-dart/lib/server.dart
+++ b/hello-grpc-dart/lib/server.dart
@@ -7,6 +7,7 @@ import 'package:logging/logging.dart';
 
 import 'common/common.dart';
 import 'common/landing.pbgrpc.dart';
+import 'common/otel.dart';
 import 'conn/conn.dart';
 
 /// Available greetings in different languages
@@ -51,6 +52,11 @@ class Server {
 
   /// Main entry point for the server
   Future<void> main(List<String> args) async {
+    // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y, before any
+    // grpc.Server() is constructed so a configured global tracer is
+    // available for any subsequent handler-side span emission.
+    await initOtel('hello-grpc-dart-server');
+
     // Set up logging
     _configureLogging();
     _logger = Logger('HelloServer');

--- a/hello-grpc-dart/pubspec.yaml
+++ b/hello-grpc-dart/pubspec.yaml
@@ -15,6 +15,11 @@ dependencies:
   grpc: ^4.0.1
   # https://pub.dev/packages/protobuf
   protobuf: ^4.0.0
+  # OpenTelemetry (for env-gated tracing behind GRPC_HELLO_OTEL=Y).
+  # The opentelemetry_dart package is still at 0.0.2 (2025) — the API
+  # surface it exposes is the minimal Provider/Exporter pair used in
+  # lib/common/otel.dart. See Otel.dart for the wiring.
+  opentelemetry_dart: ^0.0.2
   # https://pub.dev/packages/collection
   collection: ^1.19.0
   # https://pub.dev/packages/logging


### PR DESCRIPTION
Wires opentelemetry_dart 0.0.2 (the only published version on pub.dev) for env-gated tracing. Caveat carried in code: grpc-dart has no first-class OTel client/server interceptor, so handler-side spans need a follow-up PR that wraps each method in client/server.dart.