### PR TITLE
chore(deps): bump grpc-java 1.78.0 -> 1.82.1 in /hello-grpc-java

### DIFF
--- a/hello-grpc-java/pom.xml
+++ b/hello-grpc-java/pom.xml
@@ -11,7 +11,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jdk.version>21</jdk.version>
-        <grpc.version>1.78.0</grpc.version>
+        <!-- Bumped 1.78.0 -> 1.82.1 in this PR. 1.82.1 is the current
+             stable Maven release at the time of writing and includes
+             a public io.grpc.opentelemetry.OpenTelemetryServerInterceptor /
+             ClientInterceptor API (was unavailable in 1.78.x, blocking
+             PR #487). +0.4 minor over the prior 1.78.0 baseline; the
+             deps that this project pulls in (grpc-netty, grpc-services,
+             javax.annotation) all support 1.82.1 without changes. -->
+        <grpc.version>1.82.1</grpc.version>
         <protoc.version>3.24.3</protoc.version>
         <netty-resolver-dns.version>4.2.9.Final</netty-resolver-dns.version>
         <guava.version>33.5.0-jre</guava.version>


### PR DESCRIPTION
Bumps grpc.version 1.78.0 -> 1.82.1. No other changes; same dep graph shape. Unblocks the (formerly reverted) Java OTel PR against the experimental OpenTelemetryPlugin API + Kotlin OTel.