### PR TITLE
feat(java): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y (v2)

### DIFF
--- a/hello-grpc-java/pom.xml
+++ b/hello-grpc-java/pom.xml
@@ -35,6 +35,17 @@
         <lombok.version>1.18.42</lombok.version>
         <fmt-maven-plugin.version>2.29</fmt-maven-plugin.version>
         <exec-maven-plugin.version>3.6.2</exec-maven-plugin.version>
+        <!-- OpenTelemetry + contrib gRPC instrumentations.
+             We use the opentelemetry-java-contrib library
+             (io.opentelemetry.instrumentation:opentelemetry-grpc-1.6)
+             instead of io.grpc:grpc-opentelemetry because the latter
+             does not provide a stable public io.grpc.ServerInterceptor /
+             ClientInterceptor API for grpc-java 1.82.1. The contrib
+             library does, via TracingServerInterceptor /
+             TracingClientInterceptor. Both are wired from env var
+             GRPC_HELLO_OTEL=Y in OtelSupport.java. -->
+        <opentelemetry.version>1.43.0</opentelemetry.version>
+        <opentelemetry.contrib.version>2.10.0-alpha</opentelemetry.contrib.version>
     </properties>
 
     <dependencies>
@@ -43,6 +54,32 @@
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- OpenTelemetry SDK + a logging exporter so spans show up
+             without needing a sidecar Jaeger / OTLP collector. Swap
+             in OtlpGrpcSpanExporter in OtelSupport.java for prod. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+            <version>${opentelemetry.version}</version>
+        </dependency>
+        <!-- Public gRPC ServerInterceptor / ClientInterceptor for
+             grpc-java 1.82 (provided by opentelemetry-java-contrib
+             library; see OtelSupport.java for usage). -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-grpc-1.6</artifactId>
+            <version>${opentelemetry.contrib.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/client/ProtoClient.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/client/ProtoClient.java
@@ -423,8 +423,17 @@ public class ProtoClient {
    * @throws SSLException If SSL context setup fails
    */
   public void connect(ManagedChannel channel) throws SSLException {
-    ClientInterceptor interceptor = new HeaderClientInterceptor();
-    Channel interceptChannel = ClientInterceptors.intercept(channel, interceptor);
+    io.opentelemetry.api.OpenTelemetry clientOtel =
+        org.feuyeux.grpc.common.OtelSupport.initOtel("hello-grpc-java-client");
+    var chain = new java.util.ArrayList<io.grpc.ClientInterceptor>();
+    chain.add(new HeaderClientInterceptor());
+    var otelClient = org.feuyeux.grpc.common.OtelSupport.clientInterceptor(clientOtel);
+    if (otelClient != null) {
+      chain.add(otelClient);
+    }
+    Channel interceptChannel = ClientInterceptors.intercept(
+        channel,
+        chain.toArray(new io.grpc.ClientInterceptor[0]));
     blockingStub = LandingServiceGrpc.newBlockingStub(interceptChannel);
     asyncStub = LandingServiceGrpc.newStub(interceptChannel);
   }

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/common/OtelSupport.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/common/OtelSupport.java
@@ -1,0 +1,111 @@
+package org.feuyeux.grpc.common;
+
+import io.grpc.ClientInterceptor;
+import io.grpc.ServerInterceptor;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import io.opentelemetry.instrumentation.grpc.v1_6.TracingClientInterceptor;
+import io.opentelemetry.instrumentation.grpc.v1_6.TracingServerInterceptor;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.ResourceAttributes;
+
+/**
+ * OpenTelemetry wiring for hello-grpc-java.
+ *
+ * <p>Mirrors the Go (PR #486), Python (#488), Node.js+TS (#489),
+ * Rust (#490), C# (#491), C++ (#492), PHP (#493), and Dart (#494)
+ * implementations. An opt-in env var (GRPC_HELLO_OTEL=Y) installs
+ * a global OpenTelemetry SDK + tracer provider and returns
+ * {@code io.grpc.ServerInterceptor} /
+ * {@code io.grpc.ClientInterceptor} implementations
+ * ({@code TracingServerInterceptor} /
+ * {@code TracingClientInterceptor} from
+ * {@code io.opentelemetry.instrumentation:grpc-1.6}). When the env
+ * var is unset the factory methods return {@code null} so callers
+ * stay byte-identical to the pre-OTel path.
+ *
+ * <p>Note on library choice (vs. the reverted PR #487): the original
+ * attempt used classes from {@code io.grpc:grpc-opentelemetry} that
+ * do not exist in grpc-java 1.78 or 1.82.x — verified by downloading
+ * the sources jar and inspecting class names. The
+ * {@code io.opentelemetry.instrumentation:opentelemetry-grpc-1.6}
+ * contrib library exposes a stable public interceptor API that
+ * works against any grpc-java 1.6+ runtime.
+ */
+public final class OtelSupport {
+    public static final String ENV_OTEL_ENABLED = "GRPC_HELLO_OTEL";
+
+    private OtelSupport() {}
+
+    public static boolean otelEnabled() {
+        return "Y".equals(System.getenv(ENV_OTEL_ENABLED));
+    }
+
+    /**
+     * Install a logging-exporter-backed TracerProvider as the global
+     * SDK and return the same SDK so callers can pass it through to
+     * GrpcTelemetry.builder(). Returns a no-op SDK
+     * (OpenTelemetry.noop()) when the env var is off, so the
+     * deferred call at main is always safe.
+     */
+    public static OpenTelemetry initOtel(String serviceName) {
+        if (!otelEnabled()) {
+            return OpenTelemetry.noop();
+        }
+        Resource resource = Resource.getDefault()
+                .merge(Resource.create(Attributes.of(
+                        ResourceAttributes.SERVICE_NAME, serviceName)));
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+                .setResource(resource)
+                .build();
+        return OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .build();
+    }
+
+    /**
+     * Returns the OpenTelemetry {@code TracingServerInterceptor}
+     * (or {@code null} when OTel is off). Caller wraps a
+     * {@code ServerServiceDefinition} via {@code ServerInterceptors.intercept(...)}.
+     */
+    public static ServerInterceptor serverInterceptor(OpenTelemetry openTelemetry) {
+        if (!otelEnabled()) {
+            return null;
+        }
+        GrpcTelemetry grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build();
+        return new TracingServerInterceptor(grpcTelemetry);
+    }
+
+    /**
+     * Returns the OpenTelemetry {@code TracingClientInterceptor}
+     * (or {@code null} when OTel is off). Caller chains it via
+     * {@code ClientInterceptors.intercept(channel, ...)}.
+     */
+    public static ClientInterceptor clientInterceptor(OpenTelemetry openTelemetry) {
+        if (!otelEnabled()) {
+            return null;
+        }
+        GrpcTelemetry grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build();
+        return new TracingClientInterceptor(grpcTelemetry);
+    }
+
+    /** Force the Tracer to be available globally so any service-side
+     *  manual span emission has a configured tracer to use. */
+    public static Tracer tracer(OpenTelemetry openTelemetry) {
+        return openTelemetry.getTracer("hello-grpc-java");
+    }
+
+    /** Marker onAttribute() re-export to avoid breaking the ResourceAttributes
+     *  AttributeKey API surface for callers. */
+    public static AttributeKey<String> serviceNameKey() {
+        return ResourceAttributes.SERVICE_NAME;
+    }
+}

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/server/ProtoServer.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/server/ProtoServer.java
@@ -21,12 +21,15 @@ import io.netty.handler.ssl.SslContextBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import org.feuyeux.grpc.client.HeaderClientInterceptor;
 import org.feuyeux.grpc.common.Connection;
 import org.feuyeux.grpc.proto.LandingServiceGrpc;
+import io.opentelemetry.api.OpenTelemetry;
+import org.feuyeux.grpc.common.OtelSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +113,15 @@ public class ProtoServer {
    */
   public ProtoServer(LandingServiceImpl landingService)
       throws IOException, ExecutionException, InterruptedException {
-    this.server = createServer(landingService);
+    // Default constructor preserves pre-OTel behavior by passing a
+    // no-op SDK; createServer() consults OtelSupport.otelEnabled() for
+    // the interceptor factory.
+    this(landingService, OtelSupport.initOtel("hello-grpc-java-server"));
+  }
+
+  public ProtoServer(LandingServiceImpl landingService, OpenTelemetry otel)
+      throws IOException, ExecutionException, InterruptedException {
+    this.server = createServer(landingService, otel);
     start(landingService);
   }
 
@@ -196,10 +207,21 @@ public class ProtoServer {
    * @return A configured Server instance
    * @throws SSLException If TLS context setup fails
    */
-  private Server createServer(LandingServiceImpl landingService) throws SSLException {
-    // Apply server interceptors to the service
+  private Server createServer(LandingServiceImpl landingService, OpenTelemetry otel)
+      throws SSLException {
+    // Apply server interceptors to the service. The OTel interceptor
+    // is null when GRPC_HELLO_OTEL is unset, so the chain is
+    // byte-identical to before this commit.
+    var chain = new ArrayList<io.grpc.ServerInterceptor>();
+    chain.add(new HeaderServerInterceptor());
+    var otelServer = OtelSupport.serverInterceptor(otel);
+    if (otelServer != null) {
+      chain.add(otelServer);
+    }
     ServerServiceDefinition interceptedService =
-        ServerInterceptors.intercept(landingService, new HeaderServerInterceptor());
+        ServerInterceptors.intercept(
+            landingService,
+            chain.toArray(new io.grpc.ServerInterceptor[0]));
 
     // Determine if secure mode is enabled
     String secureMode = System.getenv(GRPC_HELLO_SECURE);


### PR DESCRIPTION
Replaces reverted #487 with the correct OTel library: io.opentelemetry.instrumentation:opentelemetry-grpc-1.6 (the public ServerInterceptor / ClientInterceptor implementation). Uses TracingServerInterceptor + TracingClientInterceptor. Built on top of PR #495 dep bump.