### PR TITLE
feat(kotlin): opt-in OpenTelemetry tracing via GRPC_HELLO_OTEL=Y

### DIFF
--- a/hello-grpc-kotlin/build.gradle.kts
+++ b/hello-grpc-kotlin/build.gradle.kts
@@ -24,6 +24,12 @@ ext["protobufJavaUtilVersion"] = "4.28.2"
 ext["log4jVersion"] = "2.24.0"
 //https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api-kotlin
 ext["log4jKotlinVersion"] = "1.5.0"
+// OpenTelemetry SDK + contrib gRPC instrumentations, mirroring
+// the hello-grpc-java wiring (PR #496) without the grpc-java dep
+// bump since Kotlin's grpc-java version is held at 1.68.0 by the
+// grpc-kotlin-stub dependency above.
+val opentelemetryVersion = "1.43.0"
+val opentelemetryContribVersion = "2.10.0-alpha"
 //https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core
 ext["jacksonVersion"] = "2.16.1"
 

--- a/hello-grpc-kotlin/client/src/main/kotlin/org/feuyeux/grpc/ProtoClient.kt
+++ b/hello-grpc-kotlin/client/src/main/kotlin/org/feuyeux/grpc/ProtoClient.kt
@@ -57,7 +57,18 @@ suspend fun main() = coroutineScope {
         logger.info("Connection attempt $attempt/$RETRY_ATTEMPTS")
 
         try {
-            val channel = Connection.getChannel(HeaderClientInterceptor())
+            // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y, then
+            // build the interceptor chain. Otel.clientInterceptor()
+            // returns null when the env var is unset, so the chain
+            // degrades to the pre-OTel single-interceptor shape.
+            val otel = Otel.initOtel("hello-grpc-kotlin-client")
+            val otelClient = Otel.clientInterceptor(otel)
+            val interceptors = if (otelClient != null) {
+                arrayOf(HeaderClientInterceptor(), otelClient)
+            } else {
+                arrayOf<io.grpc.ClientInterceptor>(HeaderClientInterceptor())
+            }
+            val channel = Connection.getChannel(*interceptors)
             ProtoClient(channel).use { client ->
                 val success = runGrpcCalls(client, REQUEST_DELAY_MS, ITERATION_COUNT)
                 if (success || shutdownRequested) {

--- a/hello-grpc-kotlin/server/build.gradle.kts
+++ b/hello-grpc-kotlin/server/build.gradle.kts
@@ -14,6 +14,14 @@ dependencies {
     implementation(project(":stub"))
     implementation(project(":client"))
     runtimeOnly("io.grpc:grpc-netty:${rootProject.ext["grpcVersion"]}")
+    // OpenTelemetry SDK + contrib gRPC instrumentations. The contrib
+    // package's TracingServerInterceptor / TracingClientInterceptor
+    // implement io.grpc.ServerInterceptor / ClientInterceptor
+    // respectively and work against any grpc-java 1.6+ runtime.
+    implementation("io.opentelemetry:opentelemetry-api:${opentelemetryVersion}")
+    implementation("io.opentelemetry:opentelemetry-sdk:${opentelemetryVersion}")
+    implementation("io.opentelemetry:opentelemetry-exporter-logging:${opentelemetryVersion}")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:${opentelemetryContribVersion}")
     testImplementation(kotlin("test"))
 }
 

--- a/hello-grpc-kotlin/server/src/main/kotlin/org/feuyeux/grpc/ProtoServer.kt
+++ b/hello-grpc-kotlin/server/src/main/kotlin/org/feuyeux/grpc/ProtoServer.kt
@@ -11,6 +11,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import javax.net.ssl.SSLException
+import io.opentelemetry.api.OpenTelemetry
 
 /**
  * Certificate paths for TLS configuration
@@ -125,9 +126,26 @@ class ProtoServer {
     private fun createServer(): Server? {
         // Create service implementation
         val landingService = LandingService()
-        
-        // Apply server interceptors
-        val interceptedService = ServerInterceptors.intercept(landingService, HeaderServerInterceptor())
+
+        // Initialize OpenTelemetry when GRPC_HELLO_OTEL=Y. The init
+        // hook returns OpenTelemetry.noop() when the env var is
+        // unset, so the server interceptor factory below degrades to
+        // a no-op chain in the default case.
+        val otel = Otel.initOtel("hello-grpc-kotlin-server")
+
+        // Apply server interceptors: header propagation always;
+        // OTel appended when enabled.
+        val otelServer = Otel.serverInterceptor(otel)
+        val serverChain = if (otelServer != null) {
+            ServerInterceptors.intercept(
+                landingService,
+                HeaderServerInterceptor(),
+                otelServer
+            )
+        } else {
+            ServerInterceptors.intercept(landingService, HeaderServerInterceptor())
+        }
+        val interceptedService = serverChain
         
         // Determine if secure mode is enabled
         val secureMode = System.getenv("GRPC_HELLO_SECURE")

--- a/hello-grpc-kotlin/stub/build.gradle.kts
+++ b/hello-grpc-kotlin/stub/build.gradle.kts
@@ -22,6 +22,14 @@ dependencies {
     api("org.apache.logging.log4j:log4j-core:${rootProject.ext["log4jVersion"]}")
     api("com.fasterxml.jackson.core:jackson-databind:${rootProject.ext["jacksonVersion"]}")
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${rootProject.ext["jacksonVersion"]}")
+    // OpenTelemetry SDK + contrib gRPC instrumentations. Used by
+    // hello-grpc-kotlin's server + client to wire up env-gated
+    // tracing. Lives here (stub module) so the api/transport splits
+    // are consistent with the rest of the OTel deps in the project.
+    api("io.opentelemetry:opentelemetry-api:${opentelemetryVersion}")
+    api("io.opentelemetry:opentelemetry-sdk:${opentelemetryVersion}")
+    api("io.opentelemetry:opentelemetry-exporter-logging:${opentelemetryVersion}")
+    api("io.opentelemetry.instrumentation:opentelemetry-grpc-1.6:${opentelemetryContribVersion}")
     testImplementation(kotlin("test"))
 }
 

--- a/hello-grpc-kotlin/stub/src/main/kotlin/org/feuyeux/grpc/Otel.kt
+++ b/hello-grpc-kotlin/stub/src/main/kotlin/org/feuyeux/grpc/Otel.kt
@@ -1,0 +1,71 @@
+package org.feuyeux.grpc
+
+import io.grpc.ClientInterceptor
+import io.grpc.ServerInterceptor
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.exporter.logging.LoggingSpanExporter
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry
+import io.opentelemetry.instrumentation.grpc.v1_6.TracingClientInterceptor
+import io.opentelemetry.instrumentation.grpc.v1_6.TracingServerInterceptor
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.opentelemetry.semconv.ResourceAttributes
+
+/**
+ * OpenTelemetry wiring for hello-grpc-kotlin.
+ *
+ * Mirrors the Go (PR #486), Python (#488), Node.js+TS (#489),
+ * Rust (#490), C# (#491), C++ (#492), PHP (#493), Dart (#494),
+ * and Java (#496) implementations. opt-in via GRPC_HELLO_OTEL=Y.
+ *
+ * Library choice mirrors the Java #496 PR:
+ * io.opentelemetry.instrumentation:opentelemetry-grpc-1.6 provides
+ * TracingServerInterceptor / TracingClientInterceptor as
+ * io.grpc.ServerInterceptor / ClientInterceptor implementations.
+ */
+object Otel {
+    const val ENV_OTEL_ENABLED = "GRPC_HELLO_OTEL"
+
+    fun enabled(): Boolean = System.getenv(ENV_OTEL_ENABLED) == "Y"
+
+    @JvmStatic
+    fun initOtel(serviceName: String): OpenTelemetry {
+        if (!enabled()) return OpenTelemetry.noop()
+        val resource: Resource = Resource.getDefault().merge(
+            Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, serviceName))
+        )
+        val tracerProvider = SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+            .setResource(resource)
+            .build()
+        return OpenTelemetrySdk.builder()
+            .setTracerProvider(tracerProvider)
+            .build()
+    }
+
+    @JvmStatic
+    fun serverInterceptor(openTelemetry: OpenTelemetry): ServerInterceptor? {
+        if (!enabled()) return null
+        val grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build()
+        return TracingServerInterceptor(grpcTelemetry)
+    }
+
+    @JvmStatic
+    fun clientInterceptor(openTelemetry: OpenTelemetry): ClientInterceptor? {
+        if (!enabled()) return null
+        val grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build()
+        return TracingClientInterceptor(grpcTelemetry)
+    }
+
+    @JvmStatic
+    fun tracer(openTelemetry: OpenTelemetry): Tracer =
+        openTelemetry.getTracer("hello-grpc-kotlin")
+
+    @JvmStatic
+    fun serviceNameKey(): AttributeKey<String> = ResourceAttributes.SERVICE_NAME
+}


### PR DESCRIPTION
Wires opentelemetry-grpc-1.6 in hello-grpc-kotlin behind GRPC_HELLO_OTEL=Y. Java mirror pattern from #496. grpc-java stays at 1.68.0 (the contrib library supports 1.6+).