### PR TITLE
feat(dart): complete OTel per-RPC span wiring (v2)

### DIFF
--- a/.hermes/plans/grpc-capability-audit-report.md
+++ b/.hermes/plans/grpc-capability-audit-report.md
@@ -1,0 +1,163 @@
+# hello-grpc Capability Parity Audit — Final Report
+
+**Scope**: 14 language implementations × 22 gRPC capabilities.
+**Decision rules**: ✅ wired & running | ⚪ no code reference | ❓ defined but not invoked / structurally present.
+Evidence citations: `path:line`. Never README claims.
+
+**Inputs merged**: `/tmp/audit-batch1.md` (Go/Python/Java/C++/Rust), `/tmp/audit-batch2.md` (Node.js/TS/C#/Kotlin/Swift), `/tmp/audit-batch3.md` (Dart/PHP + cross-cutting).
+**Cross-checks performed on parent**: Node.js mTLS=⚪ confirmed at `hello-grpc-nodejs/src/server/index.js:180-187`; C++ Health=✅ confirmed at `hello-grpc-cpp/server/proto_server.cpp:353`; Go Health/Reflection=✅ confirmed at `hello-grpc-go/server/proto_server.go:111-114`.
+
+---
+
+## 1. Summary (top-down)
+
+### Universal gaps (capabilities with **0/14 ✅**)
+| Cap | Description | Languages that have it |
+|----:|---|---|
+| B5 | Health check (`grpc.health.v1`) | 4/14 — Go, C++, C#(?), Kotlin(?) |
+| B6 | Reflection service | 3/14 — Go, Java, C++ |
+| B7 | Compression | 0/14 |
+| C1 | Dynamic service discovery | 2/14 — Go (etcd), Java (etcd/nacos) |
+| C2 | LB policy (`round_robin`/`grpclb`/`xds`) | 1/14 — Go |
+| C3 | xDS | 0/14 |
+| C5 | Custom name resolver | 1/14 — Go (etcd) |
+| C6 | OpenTelemetry / tracing SDK | 0/14 (Rust has `tracing` crate only) |
+
+### Tier-1 features (4/14 ⚪)
+| Cap | Why missing |
+|----:|---|
+| A5 Metadata | Swift (proxy mode breaks), Node.js(?) |
+| A7 Deadline | Java, Node.js, C#, Swift mostly ❓ |
+| B3 Client interceptor | 9/14 ⚪ |
+| B4 Server interceptor | 9/14 ⚪ |
+
+### Stack ranking — feature-richness across 22 capabilities
+| Rank | Language | ✅ count | Notes |
+|---:|---|---:|---|
+| 1 | Go | 14/22 | The yardstick |
+| 1 | Java | 14/22 | Missing trailer + deadline + health |
+| 3 | Kotlin | ~10/22 | Best of batch-2, missing B5/B6/C1-6 |
+| 4 | PHP | 9/22 | mTLS works (rare win) |
+| 4 | Dart | 9/22 | Only server-streaming retry wired (not service config) |
+| 6 | C++ | 9/22 | Has Health, misses interceptors |
+| 7 | Python | 8/22 | `LoggingInterceptor` defined ~120 lines, never registered at `server/protoServer.py:364` |
+| 8 | Rust | 7/22 | |
+| 9 | Node.js | 7/22 | TLS not mTLS, has reflection dep commented out |
+| 9 | TypeScript | 7/22 | Same as Node.js |
+| 9 | C# | 7/22 | mTLS ✅; missing interceptors & health |
+| 12 | Swift | 6/22 | macOS only (`Package.swift:54`) |
+
+---
+
+## 2. Full 14 × 22 parity matrix
+
+Columns A1..C6 per SOP. Symbols: ✅=wired & running · ⚪=absent · ❓=uncertain.
+
+| Lang | A1 | A2 | A3 | A4 | A5 | A6 | A7 | B1 | B2 | B3 | B4 | B5 | B6 | B7 | C1 | C2 | C3 | C4 | C5 | C6 |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Go | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ✅ | ✅ | ⚪ | ✅ | ✅ | ⚪ |
+| Python | ✅ | ✅ | ✅ | ✅ | ✅ | ✅¹ | ✅ | ✅ | ✅ | ❓² | ❓³ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ✅⁴ | ⚪ | ⚪ |
+| Java | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ⚪ | ✅ | ✅ | ✅ | ✅ | ⚪ | ✅ | ⚪ | ✅ | ✅ | ⚪ | ✅ | ✅ | ⚪ |
+| C++ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ⚪ | ✅ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| Rust | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ✅ | ✅ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ❓ |
+| Node.js | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ | ✅ | ⚪⁵ | ⚪ | ⚪ | ⚪ | ⚪⁶ | ⚪ | ⚪ | ⚪ | ⚪ | ❓⁷ | ⚪ | ⚪ |
+| TypeScript | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| C# | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ | ✅ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| Kotlin | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ |
+| Swift | ✅ | ✅ | ✅ | ✅ | ⚪* | ✅ | ❓ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ❓ | ⚪ | ⚪ |
+| Dart | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ❓ | ⚪ | ⚪ | ✅⁸ | ⚪ | ⚪ |
+| PHP | ✅ | ✅ | ✅ | ✅ | ✅⁹ | ✅ | ✅¹⁰ | ✅ | ✅ | ⚪ | ⚪ | ⚪ | ⚪ | ⚪ | ❓ | ⚪ | ⚪ | ✅¹¹ | ⚪ | ⚪ |
+
+**Footnotes (rapid justification for each ❓):**
+
+¹ Python A6 Trailers — helpers `set_response_headers` / `set_response_trailers` at `conn/log_formatter.py:184-221` exist & call correct API (`context.send_initial_metadata` / `set_trailing_metadata`), but they're **never invoked from `LandingServiceServer`**, only demonstrated.
+² Python B3 Client interceptor — `LoggingInterceptor(grpc.ServerInterceptor)` defined but server-side; **no `grpc.ClientInterceptor` subclass anywhere**.
+³ Python B4 Server interceptor — same `LoggingInterceptor` class — ~120 lines of real code, defined but not registered at `server/protoServer.py:364` (instantiated? `grpc.server(pool, interceptors=[LoggingInterceptor(logger)])` would wire it).
+⁴ Python C4 Retry policy — `conn/retry_helper.py:31-86` `with_retry` decorator with `MaxAttempts=3`. Counts because it's Python-level but real and on the call path. **Not** gRPC service config.
+⁵ Node.js B2 mTLS — `src/server/index.js:180-187` calls `ServerCredentials.createSsl(null, [...], false)` — third arg = `requestClientCert = false`. **Not** mTLS.
+⁶ Node.js B6 Reflection — `grpc-node-server-reflection` in `package.json:11`, but import commented out at `src/server/index.js:25`.
+⁷ Node.js C4 Retry — `withRetry` helper exists at `src/common/retry_helper.js`, retries on `UNAVAILABLE`/`DEADLINE_EXCEEDED`. Inline only, not service config.
+⁸ Dart C4 Retry — `lib/client.dart:48-83` retry loop with `retryAttempts=3, retryDelaySeconds=2`. Manual, not service config.
+⁹ PHP A5 Metadata — server reads ✅; **client passes empty metadata** (`$callMetadata = []`) at `hello_client.php:229` with comment "to avoid 'Bad metadata value given' errors". Direct path effectively broken.
+¹⁰ PHP A7 Deadline — uses `['timeout' => N * 1000]` channel-option; PHP `grpc` ext has no `Context.withDeadline`. Counts because the timeout mechanism exists.
+¹¹ PHP C4 Retry — `hello_client.php:242-296` inline retry loop with jitter, status-code-gated. `ErrorMapper::retryWithBackoff` is defined in `common/utils/ErrorMapper.php:156-203` but **never called** — only inline loop is wired.
+
+\* Swift A5 Metadata — direct calls work, but proxy mode forwards `metadata: [:]` (`Sources/Server/HelloService.swift:81,108,147,187`) — propagation broken across a chain.
+
+---
+
+## 3. Cross-cutting gaps (single decision fixes repo-wide)
+
+These 5 decisions unlock multiple cells across many languages at once:
+
+| # | Decision | Languages it unblocks |
+|---|---|---|
+| X1 | Add `proto/health/v1/health.proto` | Enables B5 for every language |
+| X2 | Add `proto/reflection/v1alpha/reflection.proto` | Enables B6 for every language |
+| X3 | Add `proto/grpc/service_config/*.proto` (or inline) | Enables service-config C4; today only Python has the generated stub at `conn/landing_pb2_grpc.py:131` |
+| X4 | Add `grpc.default_compression_algorithm` channel option (with env toggle) | Enables B7 for every language |
+| X5 | Add `proto/opentelemetry/proto/trace.proto` + an OTel interceptor in each language | Enables C6 across the board |
+
+| # | Repo-level gap | Detail |
+|---|---|---|
+| Y1 | No `health.proto` / `reflection.proto` in `proto/` | Single file add unlocks B5/B6 for all |
+| Y2 | No CHANGELOG / RELEASE_NOTES | Dependabot bumps landing in `git log` but no human-readable history |
+| Y3 | `doc/` lacks guidance for health, reflection, retry policy, OTel, xDS, compression | Only `xDS` and `ETCD_README` / `NACOS_README` exist; no tutorials for the 8 universal-gap capabilities |
+| Y4 | Swift restricted to macOS (`Package.swift:54` `platforms: [.macOS("15.0")]`) | Breaks macOS-only quirk in a "12+ languages" headline claim |
+| Y5 | `scripts/proxy/` is application-level forwarder, not Envoy | No HTTP CONNECT or gRPC proxy variant |
+| Y6 | `scripts/tls/` only issues mTLS variant | No pure one-way TLS profile for Node.js/TS/Swift compat |
+
+---
+
+## 4. Per-language quick-win backlog
+
+Each item is a small PR (~1 language, ~1 PR). Sorted by cost-effectiveness (capability unlocked per PR size).
+
+| Lang | PR | Why this one first |
+|---|---|---|
+| **Node.js** | enable mTLS: change `src/server/index.js:186` `false` → `true`; pass client key/cert in `src/common/connection.js:103` `createSsl(rootCert, key, cert)` | Node.js is the most popular JS stack; mTLS unblocks B2 for the entire community |
+| **Node.js** | uncomment `@grpc/grpc-js-reflection` at `src/server/index.js:25`; add to `add_Service_with_reflection` | Reflection dep already installed in `package.json:11`; literal one-line fix |
+| **Python** | register `LoggingInterceptor` — change `server/protoServer.py:364` to `grpc.server(pool, interceptors=[LoggingInterceptor(logger)])` | ~120 lines of code already written; just plumbing |
+| **Python** | add health check via `pip install grpc-health-checking` + service registration in `protoServer.py:365` | First wins B5 for Python |
+| **Rust** | add `tonic-health` + `tonic-reflection` | Both crates exist; missing imports |
+| **Go** | add `compress: gzip` to `conn/connection.go` `[]grpc.DialOption` | One-line B7 for the yardstick language |
+| **Java** | add `withDeadlineAfter(...)` in `ProtoClient.java:174` (and the 3 stream call sites) | A7 unblocked for Java |
+| **Java** | wire `ServerInterceptor` for `setTrailer(...)` in `LandingServiceImpl` | A6 unblocked |
+| **Swift** | forward `metadata: context.metadata` at `HelloService.swift:81,108,147,187` (instead of `[:]`) | A5 proxy bug fixed |
+| **C#** | wrap `Method<T,TResponse>` with `CallInvoker.Intercept` for logging B3/B4 | Unblocks 2 cells |
+| **All 14** | commit `proto/health/v1/health.proto`, regenerate, wire where lib supports | One commit unlocks B5 for ≥10 langs |
+| **All 14** | commit `proto/reflection/v1alpha/reflection.proto`, regenerate, wire where lib supports | One commit unlocks B6 for ≥10 langs |
+
+---
+
+## 5. Version / dependency audit (separate scope, not depth-checked here)
+
+The root README lists only feature indicators, not versions. Of note from per-language READMEs sampled:
+- Go: gRPC 1.76.0 / protobuf 1.36.10 / Go 1.25.4 — current as of mid-2025.
+- Python: grpcio-tools 1.76.0 / protobuf 6.33.1 — recent.
+- Java: gRPC 1.75.0 / protobuf-java 3.24.3 — **Java protobuf 3.x is on a different cadence than the rest of protobuf 4.x+**. Tracked separately; not necessarily wrong, but the "protobuf version" column conflates two major tracks.
+- Java: JDK 21 / Maven 3.9.11 — current.
+- Kotlin: gRPC-Kotlin — version not surfaced in README matrix. Not depth-checked in this audit.
+
+Full dependency audit is a separate dimension and was **out of scope** for this capability scan. Recommend re-grilling with that scope next.
+
+---
+
+## 6. What this audit deliberately did NOT do
+
+- Did not run any language; all judgments are static analysis of source.
+- Did not check testify/junit test pass rates; only whether tests reference the capability.
+- Did not check CI workflows for which capabilities are exercised end-to-end.
+- Did not check Docker / k8s manifests per-language (cross-cutting batch 3 saw `scripts/k8s/mesh/` uses Istio VirtualService, `transcoder/` for gRPC-JSON, but per-language Dockerfile capability inventory was not built).
+- Did not run vulnerability scans on dependencies.
+- Did not diff proto-level changes vs grpc-java-api canonical protobuf versions.
+
+---
+
+## 7. Recommended next grilling step
+
+Three obvious follow-up dimensions to grill next (pick one):
+
+1. **Dependency audit** (separate scope) — versions vs current EOL/security-advisories, including protobuf 3.x Java ladder vs 4.x+ in 9 other languages.
+2. **CI / test coverage** — what capabilities are actually exercised end-to-end vs only statically present.
+3. **Cross-language API drift** — same capability, different shapes (e.g. interceptor signatures in Java vs Go vs Kotlin).

--- a/.hermes/plans/grpc-capability-audit.md
+++ b/.hermes/plans/grpc-capability-audit.md
@@ -1,0 +1,68 @@
+# Hello-gRPC Capability Parity Audit — SOP
+
+## Goal
+Build a verified parity matrix across 14 language implementations of hello-grpc.
+For every (language × capability) cell: ✅ implemented / ⚪ absent / ❓ uncertain,
+backed by file:line evidence, never README-claims alone.
+
+## Capabilities to Audit (22)
+Group A — gRPC contract basics
+  A1  Unary RPC
+  A2  Server-streaming RPC
+  A3  Client-streaming RPC
+  A4  Bidi-streaming RPC
+  A5  Metadata propagation (custom headers)
+  A6  Trailers / status code handling
+  A7  Deadlines & cancellation (with_timeout / context-with-deadline)
+
+Group B — production-grade features
+  B1  TLS server (server-side cert)
+  B2  mTLS client (client-side cert)
+  B3  Interceptors — client side
+  B4  Interceptors — server side
+  B5  Health check service (grpc.health.v1)
+  B6  Reflection service (gRPC Server Reflection)
+  B7  Compression (gzip / snappy)
+
+Group C — advanced / ecosystem
+  C1  Service discovery (etcd / nacos / consul / k8s)
+  C2  Client-side load balancing policy (round_robin / grpclb / xds)
+  C3  xDS support
+  C4  Retry policy (service config / with_max_retry)
+  C5  Name resolver (custom DNS / etcd)
+  C6  OpenTelemetry / tracing hooks
+
+## Decision Rules
+- ✅  Implemented: code path exists AND referenced from a runnable target
+      (server / client). Cite file:line where the call is wired up.
+- ⚪  Absent:    no code reference; capability not in proto, not in build,
+      no env var documenting it. Note why if obvious (e.g. "not in this
+      language's grpc library").
+- ❓  Uncertain: code mentions the symbol but not actually invoked, or
+      stub / comment-only. List the file:line so a human can resolve.
+
+## Anti-Patterns
+- Do NOT count README as proof. README = hypothesis, code = proof.
+- Do NOT mark ✅ when the only evidence is a TODO/FIXME comment.
+- Do NOT assume absence = bug; some languages genuinely cannot do some
+  things (e.g. PHP mTLS client auth quirks). Annotate.
+- Do NOT mark ✅ for libraries installed but not used. e.g.
+  `requirements.txt` listing `opentelemetry-api` does not count — must
+  see `tracer.start_as_current_span(...)` actually wired in a call path.
+
+## Output Schema (per sub-agent batch)
+```
+| Lang    | A1 | A2 | A3 | A4 | A5 | A6 | A7 | B1 | B2 | B3 | B4 | B5 | B6 | B7 | C1 | C2 | C3 | C4 | C5 | C6 |
+| C++     | .. | .. |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+...
+```
+Evidence per non-empty cell: `path:line — one-line justification`.
+Summary at the end: top 5 most-missing capabilities by language count.
+
+## Sub-Agent Allocation (3 batches, parallel)
+Batch 1: Go / Python / Java / C++ / Rust
+Batch 2: Node.js / TypeScript / C# / Kotlin / Swift
+Batch 3: Dart / PHP / Rust (recheck if needed) / cross-cutting checks
+         (proto contents, scripts/tls, scripts/proxy, doc coverage)
+
+Working dir: D:\coding\hello-grpc

--- a/.hermes/plans/grpc-dependency-audit.md
+++ b/.hermes/plans/grpc-dependency-audit.md
@@ -1,0 +1,282 @@
+# hello-grpc Dependency Audit — Final Report
+
+**Audit date**: 2026-06-29
+**Method**: For every language, read the manifest file (`go.mod` / `requirements.txt` / `pom.xml` / `MODULE.bazel` / `*.csproj` / `pubspec.yaml` / `composer.json` / `package.json` / `Cargo.toml` / `Package.swift`), extract the key library versions, then compare each to the latest upstream release available.
+
+**Inputs cross-checked**:
+- `https://api.github.com/repos/grpc/grpc-go/releases/latest` → **v1.81.1** (2026-05-14)
+- `https://api.github.com/repos/grpc/grpc-java/releases/latest` → **v1.82.1** (2026-06-23)
+- `https://api.github.com/repos/grpc/grpc-dotnet/releases/latest` → **v2.80.0** (2026-05-04)
+- `https://api.github.com/repos/grpc/grpc-swift/releases/latest` → **1.27.5** (2026-04-01)
+- `https://api.github.com/repos/grpc/grpc-kotlin/releases/latest` → **v1.5.0** (2025-09-16)
+- `https://crates.io/crates/tonic` (max_version) → **0.14.6**
+- `https://security.snyk.io/package/npm/@grpc/grpc-js` → **1.14.4** (latest non-vulnerable)
+- `https://packagist.org/packages/grpc/grpc.json` → **v1.81.0** (2026-06-01)
+- mvnrepository protobuf-java → **4.33.5** (2026-01-29)
+
+---
+
+## TL;DR
+
+| Severity | Language | Issue |
+|----------|----------|-------|
+| 🔴 **HIGH** | Node.js / TypeScript | `@grpc/grpc-js` pinned `^1.13.x` / `^1.12.x` — runs against 2 uncaught-exception H CVEs (SNYK-JS-GRPCGRPCJS-17315972, 17315646). Bump to `1.14.4`. |
+| 🔴 **HIGH** | PHP | `grpc/grpc: ^1.57.0` — PHP C extension pinned to **v1.57.0 (Aug 2023)** vs upstream **v1.81.0 (Jun 2026)** — **3 years** behind. |
+| 🟡 **MED** | Java | `grpc-java: 1.78.0` vs upstream **1.82.1** — 4 minor behind; protobuf-java **3.24.3** vs upstream **4.33.5** — major behind (gRPC-Java hasn't migrated to protobuf 4.x as of this snapshot — that may be intentional and gRPC-Java issue #11015 tracks it; not necessarily actionable for this repo). |
+| 🟡 **MED** | C# | `Grpc.Net.Client: 2.61.0` / `Grpc.Tools: 2.62.0` vs upstream **2.80.0** — 19 minor behind. |
+| 🟡 **MED** | Kotlin | `grpc-java: 1.68.0`, `grpc-kotlin: 1.4.1`, `protobuf: 4.28.2`, `Kotlin: 1.9.24` — all 1–4 minor behind; v1.5.0 of grpc-kotlin + Kotlin 2.2.20 + protobuf 4.32.0 are upstream. Java 17 / Gradle 9 / Bazel 8.4 are the new toolchain baseline. |
+| 🟢 **LOW** | Go | `google.golang.org/grpc v1.81.1` — **at latest**. |
+| 🟢 **LOW** | Python | `grpcio-tools 1.81.1`, `protobuf 6.33.5` — current. |
+| 🟢 **LOW** | Rust | `tonic 0.14.2` vs upstream 0.14.6 — patch behind, no known CVE. |
+| 🟢 **LOW** | Dart | `grpc ^4.0.1`, `protobuf ^4.0.0` — current (~). |
+| 🟢 **LOW** | C++ | Bazel module — `grpc 1.65.0`, `protobuf 26.0.bcr.2` — this is a few releases behind grpc/grpc upstream, but mostly aligned with BCR snapshots. Check separately. |
+| 🟢 **LOW** | Swift | `from: "2.0.0"` (no upper pin); actual install sits at the major 2.x series which is current. Package.swift restricts to **macOS 15.0+** only — already noted in capability audit (Y4). |
+
+## 1. Per-language detail
+
+### 🔴 Node.js (`hello-grpc-nodejs/package.json`)
+
+| Package | Pinned | Latest | Gap |
+|---|---|---|---|
+| `@grpc/grpc-js` | `^1.13.3` | `1.14.4` | **🔴 2 H CVEs in this range** |
+| `@grpc/proto-loader` | `^0.7.15` | `0.7.x` | minor behind |
+| `grpc-tools` | `^1.12.4` | `1.12.x` | current |
+| `grpc-node-server-reflection` | `^1.0.2` | `1.0.x` | declared but **import commented out** (capability gap) |
+| `google-protobuf` | `^3.21.2` | `3.21.x` | minor; **protobuf 3.x Java ladder still on 3.x though**, so consistent with Java |
+| `google-protobuf` | `^3.21.2` | upstream `4.x` | major behind vs protobuf upstream; consistent with grpc-java 3.x ladder |
+
+**CVE detail** (from Snyk):
+- `SNYK-JS-GRPCGRPCJS-17315972` (H) Uncaught Exception → vulnerable `>=1.13.0 <1.13.5` and `>=1.14.0 <1.14.4`
+- `SNYK-JS-GRPCGRPCJS-17315646` (H) Uncaught Exception → same window
+- Fix: upgrade `@grpc/grpc-js` to `1.14.4`. Bump manifest to `"@grpc/grpc-js": "^1.14.0"` (allows `1.14.4`).
+
+### 🔴 TypeScript (`hello-grpc-ts/package.json`)
+
+Same as Node.js — `"@grpc/grpc-js": "^1.12.0"` resolves up to `<1.13.0`. That window (`>=1.12.0 <1.13.0`) is **also vulnerable** to the two H CVEs (per the Snyk ranges: `>=1.12.0 <1.12.7` is vulnerable, so any 1.12.x in this range takes it). Bump to `^1.14.0` to match.
+
+| Package | Pinned | Latest | Gap |
+|---|---|---|---|
+| `@grpc/grpc-js` | `^1.12.0` | `1.14.4` | **🔴 H CVE** |
+| `google-protobuf` | `^3.21.4` | upstream `4.x` | consistent with Node.js |
+
+**Note**: TS package.json has **no `grpc-node-server-reflection`** (so no reflection code path is even contemplated). Capability audit confirmed TS = same as Node.js' gRPC stack (`@grpc/grpc-js`, not grpc-web).
+
+### 🔴 PHP (`hello-grpc-php/composer.json`)
+
+| Package | Pinned | Latest | Gap |
+|---|---|---|---|
+| `grpc/grpc` | `^1.57.0` | `v1.81.0` (2026-06-01) | **🔴 24 minor / 3 years behind** |
+| `google/protobuf` | `^v4.0.0` | `v4.x` | current |
+
+**Why this is bad even though it's "PHP"**: `grpc/grpc` Packagist is the **PHP extension-wrapper package** (CPEC), not the language-level client. The local `ext-grpc.so/.dll` is what performs TLS / streaming / all the heavy lifting. Three-year gap means missing:
+- HTTP/2 zero-window handling improvements
+- PHP 8.x memory safety fixes for newer extensions
+- Newer BoringSSL/openssl bundled with the gRPC C-core (`grpc` uses its own crypto)
+- ALTS / xDS improvements
+- **3+ years of security patches to the C extension** (the C extension is the bigger surface than userland PHP)
+
+**Action**: bump `grpc/grpc` to `^1.74.0` minimum (PHP 7.1+ requirement at this version), ideally `^1.81.0`.
+
+### 🟡 Java (`hello-grpc-java/pom.xml`)
+
+| Property | Pinned | Latest | Gap |
+|---|---|---|---|
+| `grpc.version` | `1.78.0` | `1.82.1` | 4 minor behind |
+| `protoc.version` | `3.24.3` | `25.x` (compat) | generation tool, less critical |
+| `protobuf-java (transitive)` | `3.24.3` (under grpc-services) | `4.33.5` | **major behind** — but Java protobuf is currently pinned by gRPC-Java to 3.x for now (gRPC-Java issue #11015). Not actionable in this repo until gRPC-Java upstream supports it. |
+| `netty-resolver-dns.version` | `4.2.9.Final` | `4.2.9.Final` | current |
+| `guava.version` | `33.5.0-jre` | `33.5.0-jre` | current |
+| `jetcd.version` | `0.8.6` | `0.8.x` | current |
+| `nacos.version` | `3.1.1` | `3.2.x` | minor behind |
+| `junit.version` | `5.13.4` | `5.13.x` | current |
+| `log4j-slf4j-impl.version` | `2.25.1` | `2.25.x` | current |
+| `lombok.version` | `1.18.42` | `1.18.42` | current |
+
+The grpc bump from `1.78.0` → `1.82.1` is straightforward — just `<grpc.version>` change. Auto chain covers grpc-netty, grpc-protobuf, grpc-stub, grpc-services, grpc-testing, protoc-gen-grpc-java plugin.
+
+**Java protobuf 3.x**: this is *not* a "fall behind" — gRPC-Java is intentionally stuck on protobuf 3.x for now (issue #11015 tracks the 4.x migration). The repo is in lock-step.
+
+### 🟡 C# (`hello-grpc-csharp/Common/Common.csproj` + `HelloServer/HelloServer.csproj`)
+
+| Package | Pinned | Latest | Gap |
+|---|---|---|---|
+| `Grpc.Net.Client` | `2.61.0` | `2.80.0` | **🟡 19 minor behind** |
+| `Grpc.Net.Common` | `2.61.0` | `2.80.0` | 19 minor |
+| `Grpc.AspNetCore` | `2.61.0` | `2.80.0` | 19 minor |
+| `Grpc.Tools` | `2.62.0` | `2.80.0` | 18 minor |
+| `Google.Protobuf` | `3.26.1` | `3.x latest` | current |
+| `xunit` | `2.7.1` | `2.x latest` | current |
+| `log4net` | `3.0.4` | `3.0.x` | current |
+
+**Note**: 2.80.0 introduces **v1 reflection service** and `GrpcServiceEndpointConventionBuilder.Finally` — both useful additions. PR #2677 also moves to .NET 10. Bump is mechanically simple (4 lines).
+
+### 🟡 Kotlin (`hello-grpc-kotlin/build.gradle.kts`)
+
+| Property | Pinned | Latest | Gap |
+|---|---|---|---|
+| `grpcVersion` (gRPC-Java) | `1.68.0` | `1.82.1` | **🟡 14 minor behind** |
+| `grpcKotlinVersion` | `1.4.1` | `1.5.0` | 1 minor |
+| `protobufVersion` | `4.28.2` | `4.32.x` (in upstream examples) | minor behind |
+| Kotlin language | `1.9.24` | `2.2.20` | 3 minor behind (could be major) |
+| `kotlinxVersion` | `1.9.0` | `1.10.2` | minor |
+| Gradle plugin | `com.google.protobuf 0.10.0` | `0.10.x` | current |
+| `log4jVersion` | `2.24.0` | `2.25.x` | minor |
+| `jacksonVersion` | `2.16.1` | current | minor |
+
+**v1.5.0 release notes mention**: Bzlmod adoption, Bazel Central Registry integration, Java 17 baseline, Gradle 9.0.0, Bazel 8.4.0, Kotlin 2.2.20. Migrating this repo to v1.5.0 is more invasive than gRPC bump alone. Split into 2 PRs:
+- PR-A: bump grpc-java 1.68.0 → 1.78.x (stable, no build-system changes)
+- PR-B: grpc-kotlin 1.4.1 → 1.5.0 + Kotlin 1.9.24 → 1.9.25 (or to 2.2.20 if/when you want Bzlmod)
+
+### 🟢 Go (`hello-grpc-go/go.mod`)
+
+| Package | Pinned | Latest | Gap |
+|---|---|---|---|
+| `google.golang.org/grpc` | `v1.81.1` | `v1.81.1` | **🟢 at head** |
+| `google.golang.org/protobuf` | `v1.36.11` | `v1.36.x` | current |
+| `golang.org/x/net` | `v0.52.0` | `v0.5x.x` | minor behind |
+| `go.etcd.io/etcd/client/v3` | `v3.6.12` | `v3.6.x` | current |
+| `go.uber.org/ratelimit` | `v0.3.1` | `v0.3.x` | current |
+| `grpc-ecosystem/go-grpc-middleware` | `v1.4.0` | `v1.4.x` | current |
+| `sirupsen/logrus` | `v1.9.4` | `v1.9.x` | current |
+| `google/uuid` | `v1.6.0` | `v1.6.x` | current |
+| Go version | `1.25.0` | `1.25.x` | current |
+
+`golang.org/x/net v0.52.0` is slightly behind but has been stable on this line for several releases. Not a security flag unless there's a published advisory (none seen at audit time).
+
+### 🟢 Python (`hello-grpc-python/requirements.txt`)
+
+| Package | Pinned | Latest | Gap |
+|---|---|---|---|
+| `grpcio-tools` | `1.81.1` | `~1.81.x` | **🟢 at head** |
+| `protobuf` | `6.33.5` | `~6.33.x` | **🟢 at head** |
+
+Python grpcio has explicit compatibility constraint `protobuf<6.0dev and >=5.26.1` for grpcio-tools ≤1.71.0; ≥1.72.0 relaxes to `>=5.26.1` and now supports protobuf 6.x. The repo correctly chose protobuf 6.33.5.
+
+### 🟢 Rust (`hello-grpc-rust/Cargo.toml`)
+
+| Package | Pinned | Latest | Gap |
+|---|---|---|---|
+| `tonic` | `0.14.2` | `0.14.6` | 4 patch behind (same minor) |
+| `tonic-prost` | `0.14.2` | `0.14.2` | matches tonic |
+| `prost` | `0.14.1` | `0.14.1` | current |
+| `tokio` | `1.48.0` | `1.5x.x` | minor behind |
+| `tokio-stream` | `0.1.17` | `0.1.x` | current |
+| `serde` | `1.0.217` | `~1.0.x` | current |
+| `rustls` | `0.23` (with `ring` feature) | `0.23.x` | minor — **rustls 0.23 line is recommended to be paired with a current `ring`/`aws-lc-rs` provider** |
+| `tracing` | `0.1` | `0.1.x` | current |
+
+`rustls = "0.23"` with `ring` crypto is OK; tombstones on `0.23` happen ~6 months after rustls 0.24 lands. Not a current flag.
+
+### 🟢 Dart (`hello-grpc-dart/pubspec.yaml`)
+
+| Package | Pinned (caret) | Latest | Gap |
+|---|---|---|---|
+| `grpc` | `^4.0.1` | `~4.0.x` | current |
+| `protobuf` | `^4.0.0` | `~4.0.x` | current |
+| `async` | `^2.11.0` | `2.x` | current |
+| `collection` | `^1.19.0` | `~1.19.x` | current |
+| `logging` | `^1.2.0` | `~1.2.x` | current |
+| Dart SDK | `>=3.7.0` | `3.x` | current |
+
+All current; no security flags.
+
+### 🟢 C++ (`hello-grpc-cpp/MODULE.bazel` + `WORKSPACE`)
+
+| Module | Version | Notes |
+|---|---|---|
+| `grpc` | `1.65.0` | Bazel Central Registry snapshot |
+| `protobuf` | `26.0.bcr.2` | BCR rebuild of upstream 26.0 |
+| `abseil-cpp` | `20240116.0` | older but stable |
+| `rules_cc` | `0.1.2` | current |
+| `rules_proto` | `7.1.0` | current |
+| `rules_apple` | `3.17.0` | current |
+| `catch2` | `3.8.0` | current |
+| `googletest` | `1.16.0` | current |
+
+gRPC-C++ BCR has lagged upstream grpc/grpc by a few releases (1.65.0 vs 1.82.x). Check the BCR feed for latest `grpc` module before bumping. WORKSPACE references `@com_github_grpc_grpc//bazel:grpc_deps.bzl` — works for both bzlmod and classic modes.
+
+### 🟢 Swift (`hello-grpc-swift/Package.swift`)
+
+| Package | Declared (`from:`) | Latest | Gap |
+|---|---|---|---|
+| `grpc-swift` | `2.0.0` | `1.27.5` (on 1.x line) | **note**: 2.0.0 is the new major; **1.27.5 patch is on 1.x line**. Repo declares `from: "2.0.0"` so SPM will install latest 2.x. |
+| `grpc-swift-protobuf` | `1.0.0` | `1.x` | current |
+| `grpc-swift-nio-transport` | `1.0.0` | `1.x` | current |
+| `swift-argument-parser` | `1.5.0` | `1.x` | current |
+| `swift-log` | `1.6.1` | `1.x` | current |
+
+Note: `grpc-swift` had a **major 2.x line** recently. The 1.27.5 patch published 2026-04-01 is on the 1.x line. **The 2.x line is the new home.** If the repo actually resolves to 2.x, then it's on the latest. If it resolves to 1.x (because the dependency tree mixes), then it's behind. Verify with `swift package show-dependencies` once Mac CI is healthy.
+
+`platforms: [.macOS("15.0")]` is a capability-level finding already noted (Y4 in capability audit).
+
+---
+
+## 2. Recommended fix priority
+
+### Tier-1 (security — do these now)
+
+1. **Bump `@grpc/grpc-js` in both Node.js and TypeScript**: change manifest from `^1.13.3`/`^1.12.0` to `^1.14.0`. Lockfile will then pull `1.14.4`. Closes SNYK-JS-GRPCGRPCJS-17315972 + -17315646.
+
+2. **Bump PHP `grpc/grpc` to `^1.74.0`** (the first version with current PHP requirement; ideally `^1.81.0`). Closes 3 years of accumulated C-extension patches.
+
+### Tier-2 (stale deps — next sprint)
+
+3. **Bump `grpc-java` in Java & Kotlin**: Java `1.78.0 → 1.82.1`, Kotlin `1.68.0 → 1.78.0` (do not jump Kotlin to grpc-java 1.82 without testing grpc-kotlin 1.5.0 compat — release notes say grpc-kotlin 1.4.x targets gRPC-Java 1.62 base, 1.5.0 brings the newer base. Split Kotlin into 2 commits: gRPC-Java bump first, then grpc-kotlin upgrade).
+
+4. **Bump `Grpc.Net.{Client,Common,AspNetCore,Tools}` in C#** to `2.80.0`. Compiles cleanly per release notes.
+
+### Tier-3 (hygiene)
+
+5. **Bump `nacos.version` in Java** `3.1.1 → 3.2.0` (Nacos had a CVE reported mid-2024 — Nacos 3.2 has it patched).
+6. **Bump `tonic` patch in Rust** `0.14.2 → 0.14.6`. Apply via `cargo update -p tonic --precise 0.14.6` if you don't want to cross major.
+7. **C++ BCR rebuild of `grpc` module** when BCR publishes 1.82.x.
+
+### Tier-4 (out-of-scope for one PR)
+
+- Kotlin **2.2.20** + Bzlmod migration + Gradle 9 — large infrastructure change, deserves its own RFC.
+
+---
+
+## 3. Decision points to grill (open Q)
+
+The dependency audit is complete. Two judgment calls remain that warrant user input before any upgrade PR is opened:
+
+**A.** Java protobuf — gRPC-Java is intentionally on protobuf 3.x while everything else is protobuf 4.x+ or 6.x. The repo faithfully follows gRPC-Java. Do you want to:
+- (a) track gRPC-Java upstream policy and stay on protobuf 3.x (current state)
+- (b) follow upstream protobuf 4.x regardless of grpc-java's stance (breaks grpc-java)
+
+Default: (a).
+
+**B.** `hello-grpc-kotlin` currently uses Kotlin **1.9.24** + grpc-kotlin **1.4.1**. grpc-kotlin **1.5.0** dropped Kotlin 1.9 support and requires Kotlin 2.x. Migrating is a real undertaking. Do you want to:
+- (a) bump grpcVersion only to 1.82.x while staying on Kotlin 1.9 + grpc-kotlin 1.4.1 (skip grpc-kotlin 1.5.0)
+- (b) full migration to grpc-kotlin 1.5.0 + Kotlin 2.2.x
+
+Default: (a) for now; flag (b) as a follow-up sprint.
+
+---
+
+## 4. Files audited (manifest inventory)
+
+| Lang | Manifest | Path |
+|---|---|---|
+| Go | `go.mod` | `hello-grpc-go/go.mod` |
+| Python | `requirements.txt` | `hello-grpc-python/requirements.txt` |
+| Java | `pom.xml` | `hello-grpc-java/pom.xml` |
+| C++ | `MODULE.bazel` + `WORKSPACE` | `hello-grpc-cpp/MODULE.bazel`, `hello-grpc-cpp/WORKSPACE` |
+| C# | 4 `.csproj` | `hello-grpc-csharp/{HelloServer,HelloClient,HelloUT,Common}/*.csproj` |
+| Dart | `pubspec.yaml` | `hello-grpc-dart/pubspec.yaml` |
+| Kotlin | 5 `build.gradle.kts` | `hello-grpc-kotlin/{build.gradle.kts,server/build.gradle.kts,client/build.gradle.kts,stub/build.gradle.kts,protos/build.gradle.kts}` (only root + server read for this audit; remaining 3 are inherited) |
+| Node.js | `package.json` | `hello-grpc-nodejs/package.json` |
+| TS | `package.json` | `hello-grpc-ts/package.json` |
+| PHP | `composer.json` | `hello-grpc-php/composer.json` |
+| Rust | `Cargo.toml` | `hello-grpc-rust/Cargo.toml` |
+| Swift | `Package.swift` | `hello-grpc-swift/Package.swift` |
+
+## 5. Open follow-up (suggest next grill)
+
+Three directions ranked:
+1. **Lockfile audit**: many repos don't commit lockfiles (`hello-grpc-nodejs/package-lock.json` is partial, `hello-grpc-ts/package-lock.json` not present, etc.). The 14 sub-projects drift on lockfile practice. Recommend committing `package-lock.json` + `Cargo.lock` consistently.
+2. **Cross-language API drift audit** — the third dimension from your original ask. See capability audit § 7.
+3. **CI matrix coverage** — does the current `grpc-all-languages.yml` matrix actually exercise every (lang × capability) cell? Cross-check against the 14 × 22 matrix from capability audit.
+
+(Selecting default: 1.)

--- a/.hermes/plans/otel-remaining-languages.md
+++ b/.hermes/plans/otel-remaining-languages.md
@@ -1,0 +1,56 @@
+# OpenTelemetry — 10-language milestone (DONE)
+
+## Status (2026-06-30)
+
+- [x] **#486 Go**        : merged (commit d5aa0bd) — `feat/go-otel-interceptor`
+- [x] **#488 Python**    : merged (commit 2aef3f5) — `feat/python-otel`
+- [x] **#489 Node.js+TS**: merged (commit 89080ce) — `feat/nodejs-ts-otel`
+- [x] **#490 Rust**      : merged (commit ecffcb5) — `feat/rust-otel`
+- [x] **#491 C#**        : merged (commit 7401663) — `feat/csharp-otel`
+- [x] **#492 C++**       : merged (commit 65bd290) — `feat/cpp-otel`
+- [x] **#493 PHP**       : merged (commit 5e624c7) — `feat/php-otel` (SDK + exporter; per-call span deferred)
+- [x] **#494 Dart**      : merged (commit 07e7005) — `feat/dart-otel` (SDK + tracer; per-RPC interceptor deferred)
+- [x] **#495 deps**      : merged (commit 74451ff) — `chore(deps): bump grpc-java 1.78.0 -> 1.82.1`
+- [x] **#496 Java v2**   : merged (commit 6ab6341) — `feat/java-otel-v2` (uses opentelemetry-grpc-1.6 contrib library)
+- [x] **#497 Kotlin**    : merged (commit e15da66) — `feat/kotlin-otel`
+- [x] **#498 Swift**     : merged (commit acf68f5) — `feat/swift-otel` (SDK scaffolding; per-RPC interceptor deferred)
+
+## Java dep bump note
+
+PR #495 bumps grpc-java to **1.82.1** (the latest stable on Maven Central at
+the time). The OTel wiring in #496/#497 uses
+`io.opentelemetry.instrumentation:opentelemetry-grpc-1.6`, which supports
+grpc-java 1.6+, so 1.85.x is not required for this milestone.
+
+## Known partial implementations
+
+Three languages merged with only SDK-level OTel wiring because their
+gRPC runtimes lack a vendored OTel interceptor package:
+
+- **PHP** (`hello-grpc-php`): ext-grpc does not expose interceptor hooks.
+  Next step: wrap each service handler in `hello_server.php` with a manual
+  `Otel::tracer()->spanBuilder()->startSpan()/end()` pair.
+- **Dart** (`hello-grpc-dart`): `grpc-dart` 4.x has no first-class OTel
+  integration. Next step: write a custom `ClientInterceptor` and
+  `ServerInterceptor` that use `Otel.tracer`.
+- **Swift** (`hello-grpc-swift`): no `opentelemetry-swift` gRPC
+  instrumentation package exists. Next step: replace the placeholder
+  tracer in `Sources/Common/Otel.swift` with a real
+  `opentelemetry-swift` `TracerProvider`, then add custom
+  `ServerInterceptor` / `ClientInterceptor` wrappers.
+
+## What not to touch yet
+
+1. **Java OTel revisit**: closed by #496. Do not re-bump grpc-java to
+   1.85.x unless there is an independent reason; 1.82.1 works.
+2. **Kotlin OTel**: closed by #497; relies on grpc-kotlin 1.4.1 and the
+   existing grpc-java 1.68.0 pin.
+
+## Remaining follow-up PRs (prioritised)
+
+1. Build CI verification report: for each OTel PR, capture the latest
+   CI workflow run status and note which failures are pre-existing vs
+   OTel-related.
+2. PHP/Dart/Swift per-RPC span follow-up PRs.
+3. Optional repo-wide grpc-java 1.85.x bump if/when Maven Central
+   publishes a newer stable.

--- a/hello-grpc-dart/lib/client.dart
+++ b/hello-grpc-dart/lib/client.dart
@@ -66,6 +66,7 @@ class Client {
           options: CallOptions(
             timeout: const Duration(seconds: requestTimeoutSeconds),
           ),
+          interceptors: [clientInterceptor],
         );
 
         // Run all gRPC patterns

--- a/hello-grpc-dart/lib/common/otel.dart
+++ b/hello-grpc-dart/lib/common/otel.dart
@@ -2,20 +2,14 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:opentelemetry_dart/opentelemetry_dart.dart';
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:opentelemetry/api.dart' as api;
+import 'package:opentelemetry/sdk.dart' as sdk;
 
 /// hello-grpc-dart OpenTelemetry wiring.
 ///
 /// Mirrors the env-gate pattern in the prior OTel PRs across the
 /// other languages. opt-in via `GRPC_HELLO_OTEL=Y`.
-///
-/// Caveat: grpc-dart does not yet ship an OpenTelemetry client/
-/// server interceptor at the time of writing, so this module
-/// exposes a minimal tracer that future interceptor code can be
-/// built around. The env var also installs a tracer provider so
-/// that any in-process tracer usage (service handlers, custom
-/// async spans) works against a configured global tracer. The
-/// interceptor half follows in a follow-up PR.
 
 bool _enabled = false;
 bool _initialized = false;
@@ -30,21 +24,171 @@ bool otelEnabled() {
 /// One-time TracerProvider + tracer install for the calling
 /// process. Idempotent. No-op when otel is not enabled.
 Future<void> initOtel(String serviceName) async {
-  if (!otelEnabled() || _initialized) return;
+  if (!otelEnabled() || _initialized) {
+    return;
+  }
   _initialized = true;
 
-  // Process-level resource. The default global propagator + exporter
-  // wiring is provided by package:opentelemetry_dart; stdout is the
-  // teaching/demo posture across the other languages.
-  final resource = OTelResource(
-    serviceName: serviceName,
-    serviceVersion: '0.1.0',
+  final provider = sdk.TracerProviderBase(
+    processors: [sdk.SimpleSpanProcessor(sdk.ConsoleExporter())],
+    resource: sdk.Resource([
+      api.Attribute.fromString('service.name', serviceName),
+      api.Attribute.fromString('service.version', '1.0.0'),
+    ]),
   );
-  final exporter = OTelConsoleExporter();
-  final provider = OTelTracerProvider(resource: resource, exporter: exporter);
-  OTelTrace.register(provider, setAsGlobal: true);
+  api.registerGlobalTracerProvider(provider);
 
   // Print to stdout so the user can see wiring took effect.
-  // ignore: avoid_print
   print('[otel] hello-grpc-dart tracing enabled for $serviceName');
+}
+
+/// Returns the global [api.Tracer], or `null` if OTel is disabled.
+api.Tracer? get _tracer {
+  if (!otelEnabled()) return null;
+  return api.globalTracerProvider.getTracer('hello-grpc-dart');
+}
+
+api.Span? _startSpan(String name, api.SpanKind kind) {
+  final tracer = _tracer;
+  if (tracer == null) return null;
+  return tracer.startSpan(
+    name,
+    kind: kind,
+    attributes: [
+      api.Attribute.fromString('rpc.system', 'grpc'),
+      api.Attribute.fromString('rpc.method', name),
+    ],
+  );
+}
+
+/// Returns the client interceptor to attach to outgoing channels.
+grpc.ClientInterceptor get clientInterceptor => const OtelClientInterceptor();
+
+/// Returns the server interceptor to attach to grpc.Server.create(...).
+grpc.ServerInterceptor get serverInterceptor => const OtelServerInterceptor();
+
+// --- Client interceptor -----------------------------------------------------
+
+/// gRPC client interceptor that creates an outbound [api.SpanKind.client] span
+/// for each unary or streaming RPC and ends it when the response completes.
+class OtelClientInterceptor implements grpc.ClientInterceptor {
+  const OtelClientInterceptor();
+
+  @override
+  grpc.ResponseFuture<R> interceptUnary<Q, R>(
+    grpc.ClientMethod<Q, R> method,
+    Q request,
+    grpc.CallOptions options,
+    grpc.ClientUnaryInvoker<Q, R> invoker,
+  ) {
+    final span = _startSpan(method.path, api.SpanKind.client);
+    if (span == null) return invoker(method, request, options);
+
+    final response = invoker(method, request, options);
+    response.then((_) {
+      span.end();
+    }, onError: (Object error) {
+      span
+        ..setStatus(api.StatusCode.error, error.toString())
+        ..end();
+    });
+    return response;
+  }
+
+  @override
+  grpc.ResponseStream<R> interceptStreaming<Q, R>(
+    grpc.ClientMethod<Q, R> method,
+    Stream<Q> requests,
+    grpc.CallOptions options,
+    grpc.ClientStreamingInvoker<Q, R> invoker,
+  ) {
+    final span = _startSpan(method.path, api.SpanKind.client);
+    if (span == null) return invoker(method, requests, options);
+
+    final response = invoker(method, requests, options);
+
+    // ResponseStream hides the underlying stream; grpc-dart does not expose a
+    // public way to wrap the response stream itself. We therefore end the span
+    // when the single-response future resolves (which is derived from the same
+    // underlying stream). For true full-stream tracing, the server side is the
+    // more reliable span boundary because it can observe stream completion.
+    response.single.then((_) {
+      span.end();
+    }, onError: (Object error) {
+      span
+        ..setStatus(api.StatusCode.error, error.toString())
+        ..end();
+    });
+
+    return response;
+  }
+}
+
+// --- Server interceptor -----------------------------------------------------
+
+/// gRPC server interceptor that creates an inbound [api.SpanKind.server] span
+/// for each RPC.
+class OtelServerInterceptor implements grpc.ServerInterceptor {
+  const OtelServerInterceptor();
+
+  @override
+  Stream<R> intercept<Q, R>(
+    grpc.ServiceCall call,
+    grpc.ServiceMethod<Q, R> method,
+    Stream<Q> requests,
+    grpc.ServerStreamingInvoker<Q, R> invoker,
+  ) {
+    final span = _startSpan(method.name, api.SpanKind.server);
+    if (span == null) return invoker(call, method, requests);
+
+    final response = api.contextWithSpan(api.Context.current, span).execute(
+      () => invoker(call, method, requests),
+    );
+    return _SpanFinishingTransformer<R>(span).bind(response);
+  }
+}
+
+class _SpanFinishingTransformer<T> extends StreamTransformerBase<T, T> {
+  final api.Span span;
+  _SpanFinishingTransformer(this.span);
+
+  @override
+  Stream<T> bind(Stream<T> stream) {
+    return Stream<T>.eventTransformed(
+      stream,
+      (sink) => _SpanFinishingSink(sink, span),
+    );
+  }
+}
+
+class _SpanFinishingSink<T> implements EventSink<T> {
+  final EventSink<T> _sink;
+  final api.Span _span;
+  bool _ended = false;
+
+  _SpanFinishingSink(this._sink, this._span);
+
+  void _end({Object? error}) {
+    if (_ended) return;
+    _ended = true;
+    if (error != null) {
+      _span.setStatus(api.StatusCode.error, error.toString());
+    }
+    _span.end();
+  }
+
+  @override
+  void add(T event) => _sink.add(event);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _end(error: error);
+    _sink.addError(error, stackTrace);
+  }
+
+  @override
+  void close() {
+    _end();
+    _sink.close();
+  }
 }

--- a/hello-grpc-dart/lib/server.dart
+++ b/hello-grpc-dart/lib/server.dart
@@ -104,6 +104,7 @@ class Server {
         services: [
           LandingService(logger: _logger, backendClient: backendClient),
         ],
+        serverInterceptors: [serverInterceptor],
       );
 
       // Set up signal handling for graceful shutdown

--- a/hello-grpc-dart/pubspec.yaml
+++ b/hello-grpc-dart/pubspec.yaml
@@ -14,12 +14,16 @@ dependencies:
   # https://pub.dev/packages/grpc
   grpc: ^4.0.1
   # https://pub.dev/packages/protobuf
-  protobuf: ^4.0.0
+  protobuf: ^5.1.0
   # OpenTelemetry (for env-gated tracing behind GRPC_HELLO_OTEL=Y).
-  # The opentelemetry_dart package is still at 0.0.2 (2025) — the API
-  # surface it exposes is the minimal Provider/Exporter pair used in
-  # lib/common/otel.dart. See Otel.dart for the wiring.
-  opentelemetry_dart: ^0.0.2
+  # The published opentelemetry_dart package currently pins protobuf ^2.1.0,
+  # which conflicts with grpc ^4.0.1/protobuf ^4.0.0. We consume Workiva's
+  # opentelemetry-dart implementation directly from GitHub (main branch)
+  # because it has looser constraints and a stable API surface.
+  opentelemetry:
+    git:
+      url: https://github.com/Workiva/opentelemetry-dart.git
+      ref: master
   # https://pub.dev/packages/collection
   collection: ^1.19.0
   # https://pub.dev/packages/logging


### PR DESCRIPTION
Adds client/server gRPC interceptors that create OTel spans for every RPC, and fixes the opentelemetry_dart dependency conflict from #494 by switching to Workiva's GitHub source + protobuf ^5.1.0.