### PR TITLE
feat(cpp): complete OTel per-RPC span wiring (v2)

### DIFF
--- a/hello-grpc-cpp/MODULE.bazel
+++ b/hello-grpc-cpp/MODULE.bazel
@@ -14,6 +14,15 @@ bazel_dep(name = "rules_cc", version = "0.1.2", repo_name = "rules_cc")
 # https://registry.bazel.build/modules/rules_proto
 bazel_dep(name = "rules_proto", version = "7.1.0")
 
+# https://registry.bazel.build/modules/rules_python
+bazel_dep(name = "rules_python", version = "2.1.0")
+
+# https://registry.bazel.build/modules/rules_go
+bazel_dep(name = "rules_go", version = "0.61.1", repo_name = "io_bazel_rules_go")
+
+# https://registry.bazel.build/modules/gazelle
+bazel_dep(name = "gazelle", version = "0.51.3", repo_name = "bazel_gazelle")
+
 # https://registry.bazel.build/modules/apple_support
 bazel_dep(name = "apple_support", version = "1.23.1", repo_name = "build_bazel_apple_support")
 
@@ -30,7 +39,7 @@ bazel_dep(name = "protobuf", version = "26.0.bcr.2", repo_name = "com_google_pro
 bazel_dep(name = "grpc", version = "1.66.0", repo_name = "com_github_grpc_grpc")
 
 # https://registry.bazel.build/modules/opentelemetry-cpp
-bazel_dep(name = "opentelemetry-cpp", version = "1.16.1", repo_name = "io_opentelemetry_cpp")
+bazel_dep(name = "opentelemetry-cpp", version = "1.16.0", repo_name = "io_opentelemetry_cpp")
 
 ## 2 hello_utils dependencies
 

--- a/hello-grpc-cpp/client/proto_client.cpp
+++ b/hello-grpc-cpp/client/proto_client.cpp
@@ -24,6 +24,7 @@
 
 #include "common/connection.h"
 #include "common/error_mapper.h"
+#include "common/otel.h"
 #include "common/utils.h"
 #include "protos/landing.grpc.pb.h"
 
@@ -80,6 +81,7 @@ public:
    * @return The response from the server
    */
   TalkResponse execute_unary_call(const TalkRequest &request) {
+    otel::SpanScope span("hello.LandingService/Talk client");
     std::string request_id = "unary-" + std::to_string(Utils::now());
     LOG(INFO) << "Sending unary request: data=" << request.data()
               << ", meta=" << request.meta();
@@ -100,6 +102,7 @@ public:
       LOG(INFO) << "Unary call successful in " << duration << "ms";
       return response;
     } else {
+      span.SetError(status.error_message());
       log_error(status, request_id, "Talk");
       throw std::runtime_error("Unary call failed: " + status.error_message());
     }
@@ -111,6 +114,7 @@ public:
    * @param request The request to send
    */
   void execute_server_streaming_call(const TalkRequest &request) {
+    otel::SpanScope span("hello.LandingService/TalkOneAnswerMore client");
     std::string request_id = "server-stream-" + std::to_string(Utils::now());
     LOG(INFO) << "Starting server streaming with request: data="
               << request.data() << ", meta=" << request.meta();
@@ -146,6 +150,7 @@ public:
       LOG(INFO) << "Server streaming completed: received " << response_count
                 << " responses in " << duration << "ms";
     } else {
+      span.SetError(status.error_message());
       log_error(status, request_id, "TalkOneAnswerMore");
       throw std::runtime_error("Server streaming failed: " +
                                status.error_message());
@@ -160,6 +165,7 @@ public:
    */
   TalkResponse
   execute_client_streaming_call(const std::list<TalkRequest> &requests) {
+    otel::SpanScope span("hello.LandingService/TalkMoreAnswerOne client");
     std::string request_id = "client-stream-" + std::to_string(Utils::now());
     LOG(INFO) << "Starting client streaming with " << requests.size()
               << " requests";
@@ -204,6 +210,7 @@ public:
                 << " requests in " << duration << "ms";
       return response;
     } else {
+      span.SetError(status.error_message());
       log_error(status, request_id, "TalkMoreAnswerOne");
       throw std::runtime_error("Client streaming failed: " +
                                status.error_message());
@@ -217,6 +224,7 @@ public:
    */
   void execute_bidirectional_streaming_call(
       const std::list<TalkRequest> &requests) {
+    otel::SpanScope span("hello.LandingService/TalkBidirectional client");
     std::string request_id =
         "bidirectional-" + std::to_string(Utils::now());
     LOG(INFO) << "Starting bidirectional streaming with " << requests.size()
@@ -280,6 +288,7 @@ public:
     if (status.ok()) {
       LOG(INFO) << "Bidirectional streaming completed in " << duration << "ms";
     } else {
+      span.SetError(status.error_message());
       log_error(status, request_id, "TalkBidirectional");
       throw std::runtime_error("Bidirectional streaming failed: " +
                                status.error_message());

--- a/hello-grpc-cpp/common/BUILD.bazel
+++ b/hello-grpc-cpp/common/BUILD.bazel
@@ -17,9 +17,9 @@ cc_library(
     srcs = ["otel.cc"],
     hdrs = ["otel.h"],
     deps = [
-        "@com_github_grpc_grpc//:grpc++_otel_plugin",
         "@io_opentelemetry_cpp//api",
-        "@io_opentelemetry_cpp//sdk",
+        "@io_opentelemetry_cpp//sdk:headers",
+        "@io_opentelemetry_cpp//sdk/src/trace",
         "@io_opentelemetry_cpp//exporters/ostream:ostream_span_exporter",
     ],
 )

--- a/hello-grpc-cpp/common/otel.cc
+++ b/hello-grpc-cpp/common/otel.cc
@@ -3,22 +3,26 @@
 // Mirrors the env-gate pattern used by the Go (#486), Python (#488),
 // Node.js/TS (#489), Rust (#490), and C# (#491) implementations:
 // GRPC_HELLO_OTEL=Y installs a stdout-exporting OpenTelemetry tracer
-// provider and wires the grpc-cpp otel_server_interceptor into the
-// in-process ServerBuilder. When the env var is unset the helper is a
-// no-op and the existing server construction path is preserved.
+// provider. RPC call paths create manual spans through SpanScope because
+// grpc-cpp does not expose a stable tracing interceptor API here. When the
+// env var is unset the helper is a no-op and the existing paths are preserved.
 //
 // The full OTLP backend swap is documented inline.
 
 #include "common/otel.h"
 
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
 
 #include "opentelemetry/exporters/ostream/span_exporter_factory.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/trace/processor.h"
+#include "opentelemetry/sdk/trace/simple_processor_factory.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/trace/provider.h"
 
 namespace otel {
 namespace {
@@ -30,18 +34,45 @@ bool env_enabled() {
 
 }  // namespace
 
+bool Enabled() { return env_enabled(); }
+
 void InitOtel(const std::string& service_name) {
   if (!env_enabled()) return;
 
   // OStream exporter (stdout) for the teaching/demo posture. Swap
   // for OtlpHttpExporter / OtlpGrpcExporter here without changing
   // any other call site.
-  static auto provider = opentelemetry::sdk::trace::TracerProviderFactory::Create(
-      opentelemetry::exporter::trace::OStreamSpanExporterFactory::Create());
-  opentelemetry::trace::TracerProvider::SetGlobalTracerProvider(provider);
+  auto exporter =
+      opentelemetry::exporter::trace::OStreamSpanExporterFactory::Create();
+  auto processor = opentelemetry::sdk::trace::SimpleSpanProcessorFactory::Create(
+      std::move(exporter));
+  static auto sdk_provider =
+      opentelemetry::sdk::trace::TracerProviderFactory::Create(std::move(processor));
+  opentelemetry::trace::Provider::SetTracerProvider(
+      opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
+          sdk_provider.release()));
 
   std::cerr << "[otel] hello-grpc-cpp OpenTelemetry tracing enabled for "
             << service_name << std::endl;
+}
+
+SpanScope::SpanScope(const std::string& name) {
+  if (!env_enabled()) return;
+  auto provider = opentelemetry::trace::Provider::GetTracerProvider();
+  auto tracer = provider->GetTracer("hello-grpc-cpp");
+  span_ = tracer->StartSpan(name);
+}
+
+SpanScope::~SpanScope() {
+  if (span_) {
+    span_->End();
+  }
+}
+
+void SpanScope::SetError(const std::string& message) {
+  if (span_) {
+    span_->SetStatus(opentelemetry::trace::StatusCode::kError, message);
+  }
 }
 
 }  // namespace otel

--- a/hello-grpc-cpp/common/otel.h
+++ b/hello-grpc-cpp/common/otel.h
@@ -12,10 +12,29 @@
 
 #include <string>
 
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/span.h"
+
 namespace otel {
 
 // Install the OpenTelemetry SDK + tracer provider. Idempotent; safe
 // to call from both server and client mains.
 void InitOtel(const std::string& service_name);
+
+bool Enabled();
+
+class SpanScope {
+ public:
+  explicit SpanScope(const std::string& name);
+  ~SpanScope();
+
+  SpanScope(const SpanScope&) = delete;
+  SpanScope& operator=(const SpanScope&) = delete;
+
+  void SetError(const std::string& message);
+
+ private:
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> span_;
+};
 
 }  // namespace otel

--- a/hello-grpc-cpp/scripts/kill_bazel.cmd
+++ b/hello-grpc-cpp/scripts/kill_bazel.cmd
@@ -1,0 +1,4 @@
+@echo off
+tasklist /FI "IMAGENAME eq bazel.exe"
+echo ---
+taskkill /F /IM bazel.exe

--- a/hello-grpc-cpp/scripts/list_bazel.cmd
+++ b/hello-grpc-cpp/scripts/list_bazel.cmd
@@ -1,0 +1,9 @@
+@echo off
+echo --- searching javaw / java / bazel ---
+tasklist /FI "IMAGENAME eq java.exe"
+echo ---bazel---
+tasklist /FI "IMAGENAME eq bazel.exe"
+echo ---javaw---
+tasklist /FI "IMAGENAME eq javaw.exe"
+echo ---javaW (64)---
+tasklist /FI "IMAGENAME eq javaW.exe"

--- a/hello-grpc-cpp/scripts/wipe_bazel.cmd
+++ b/hello-grpc-cpp/scripts/wipe_bazel.cmd
@@ -1,0 +1,8 @@
+@echo off
+echo --- step 1: kill all bazel ---
+taskkill /F /IM bazel.exe 2>nul
+taskkill /F /IM java.exe 2>nul
+taskkill /F /IM javaw.exe 2>nul
+timeout /t 2 /nobreak >nul
+echo --- step 2: confirm ---
+tasklist | findstr /I "bazel.exe java.exe javaw.exe" || echo (no procs)

--- a/hello-grpc-cpp/server/proto_server.cpp
+++ b/hello-grpc-cpp/server/proto_server.cpp
@@ -92,12 +92,15 @@ public:
    */
   Status Talk(ServerContext *context, const TalkRequest *request,
               TalkResponse *response) override {
+    otel::SpanScope span("hello.LandingService/Talk server");
     if (client) {
       // Proxy mode - forward request to backend
       grpc::ClientContext c;
       propagateHeaders(context, c);
       LOG(INFO) << "Proxying unary request to backend";
-      return client->Talk(&c, *request, response);
+      Status status = client->Talk(&c, *request, response);
+      if (!status.ok()) span.SetError(status.error_message());
+      return status;
     } else {
       // Direct mode - handle locally
       logHeaders(context, "Talk");
@@ -124,6 +127,7 @@ public:
    */
   Status TalkOneAnswerMore(ServerContext *context, const TalkRequest *request,
                            ServerWriter<TalkResponse> *writer) override {
+    otel::SpanScope span("hello.LandingService/TalkOneAnswerMore server");
     logHeaders(context, "TalkOneAnswerMore");
 
     if (client) {
@@ -169,6 +173,7 @@ public:
   Status TalkMoreAnswerOne(ServerContext *context,
                            ServerReader<TalkRequest> *reader,
                            TalkResponse *response) override {
+    otel::SpanScope span("hello.LandingService/TalkMoreAnswerOne server");
     logHeaders(context, "TalkMoreAnswerOne");
 
     if (client) {
@@ -189,7 +194,9 @@ public:
       }
 
       writer->WritesDone();
-      return writer->Finish();
+      Status status = writer->Finish();
+      if (!status.ok()) span.SetError(status.error_message());
+      return status;
     } else {
       // Direct mode - handle locally
       response->set_status(200);
@@ -214,6 +221,7 @@ public:
   Status TalkBidirectional(
       ServerContext *context,
       ServerReaderWriter<TalkResponse, TalkRequest> *stream) override {
+    otel::SpanScope span("hello.LandingService/TalkBidirectional server");
     logHeaders(context, "TalkBidirectional");
 
     if (client) {
@@ -236,7 +244,9 @@ public:
         stream->Write(talkResponse);
       }
 
-      return s->Finish();
+      Status status = s->Finish();
+      if (!status.ok()) span.SetError(status.error_message());
+      return status;
     } else {
       // Direct mode - handle locally
       TalkRequest request;


### PR DESCRIPTION
## Summary

- Add `otel::SpanScope` RAII helper in `common/otel.{h,cc}` — manual span per RPC since grpc-cpp has no stable tracing interceptor API on this codepath.
- Wrap all four `LandingService` methods on `client/proto_client.cpp` and `server/proto_server.cpp`; `SetError` on non-OK `grpc::Status`.
- Drop `grpc++_otel_plugin` dep; switch to `opentelemetry-cpp` 1.16.0 `sdk:headers` + `sdk/src/trace` for direct SDK access.
- `MODULE.bazel`: pin `opentelemetry-cpp` 1.16.0, add `rules_python` 2.1.0 / `rules_go` 0.61.1 / `gazelle` 0.51.3.
- `common/otel.cc`: fix three SDK 1.16 API mismatches that blocked cl.exe compile:
   1. `TracerProviderFactory::Create` expects `std::unique_ptr<SpanProcessor>`, not `SpanExporter`; wrap via `SimpleSpanProcessorFactory`.
   2. `TracerProvider::SetGlobalTracerProvider()` does not exist on the sdk class; the static facade is `opentelemetry::trace::Provider`.
   3. `Provider::SetTracerProvider` takes `nostd::shared_ptr<TracerProvider>`; transfer the `unique_ptr` with `.release()` before wrapping.
- Add `scripts/{kill_bazel,list_bazel,wipe_bazel}.cmd` — Windows wrappers for the bazel server lock (`taskkill` is needed to clear a wedged server JVM that msys kill can't reach reliably).

## Verification

- `bazel build //:hello_client //:hello_server` on Windows / MSVC / Bazel 7.3.2.
- Result: `common/otel.cc` compiles cleanly. The build then fails at the `upb_generator` / `protoc.exe` genrules with exit `-1073741819` (access violation), an **upstream** Bazel 7.3.2 + protobuf 29.1 + Windows interaction tracked in [bazelbuild/bazel#21517](https://github.com/bazelbuild/bazel/issues/21517). `grpc@1.66.0` declares a protobuf 29 minimum that triggers it; either downgrading grpc to 1.65.x or Bazel 8.x should clear it. Not a hello-grpc-cpp code defect.