### PR TITLE
feat(java): complete OTel per-RPC span wiring (v2)

### DIFF
--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/client/ProtoClient.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/client/ProtoClient.java
@@ -5,7 +5,6 @@ import static org.feuyeux.grpc.common.HelloUtils.buildLinkRequests;
 import static org.feuyeux.grpc.common.HelloUtils.getVersion;
 
 import io.grpc.Channel;
-import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
@@ -431,9 +430,8 @@ public class ProtoClient {
     if (otelClient != null) {
       chain.add(otelClient);
     }
-    Channel interceptChannel = ClientInterceptors.intercept(
-        channel,
-        chain.toArray(new io.grpc.ClientInterceptor[0]));
+    Channel interceptChannel =
+        ClientInterceptors.intercept(channel, chain.toArray(new io.grpc.ClientInterceptor[0]));
     blockingStub = LandingServiceGrpc.newBlockingStub(interceptChannel);
     asyncStub = LandingServiceGrpc.newStub(interceptChannel);
   }

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/common/OtelSupport.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/common/OtelSupport.java
@@ -19,93 +19,86 @@ import io.opentelemetry.semconv.ResourceAttributes;
 /**
  * OpenTelemetry wiring for hello-grpc-java.
  *
- * <p>Mirrors the Go (PR #486), Python (#488), Node.js+TS (#489),
- * Rust (#490), C# (#491), C++ (#492), PHP (#493), and Dart (#494)
- * implementations. An opt-in env var (GRPC_HELLO_OTEL=Y) installs
- * a global OpenTelemetry SDK + tracer provider and returns
- * {@code io.grpc.ServerInterceptor} /
- * {@code io.grpc.ClientInterceptor} implementations
- * ({@code TracingServerInterceptor} /
- * {@code TracingClientInterceptor} from
- * {@code io.opentelemetry.instrumentation:grpc-1.6}). When the env
- * var is unset the factory methods return {@code null} so callers
- * stay byte-identical to the pre-OTel path.
+ * <p>Mirrors the Go (PR #486), Python (#488), Node.js+TS (#489), Rust (#490), C# (#491), C++
+ * (#492), PHP (#493), and Dart (#494) implementations. An opt-in env var (GRPC_HELLO_OTEL=Y)
+ * installs a global OpenTelemetry SDK + tracer provider and returns {@code
+ * io.grpc.ServerInterceptor} / {@code io.grpc.ClientInterceptor} implementations ({@code
+ * TracingServerInterceptor} / {@code TracingClientInterceptor} from {@code
+ * io.opentelemetry.instrumentation:grpc-1.6}). When the env var is unset the factory methods return
+ * {@code null} so callers stay byte-identical to the pre-OTel path.
  *
- * <p>Note on library choice (vs. the reverted PR #487): the original
- * attempt used classes from {@code io.grpc:grpc-opentelemetry} that
- * do not exist in grpc-java 1.78 or 1.82.x — verified by downloading
- * the sources jar and inspecting class names. The
- * {@code io.opentelemetry.instrumentation:opentelemetry-grpc-1.6}
- * contrib library exposes a stable public interceptor API that
- * works against any grpc-java 1.6+ runtime.
+ * <p>Note on library choice (vs. the reverted PR #487): the original attempt used classes from
+ * {@code io.grpc:grpc-opentelemetry} that do not exist in grpc-java 1.78 or 1.82.x — verified by
+ * downloading the sources jar and inspecting class names. The {@code
+ * io.opentelemetry.instrumentation:opentelemetry-grpc-1.6} contrib library exposes a stable public
+ * interceptor API that works against any grpc-java 1.6+ runtime.
  */
 public final class OtelSupport {
-    public static final String ENV_OTEL_ENABLED = "GRPC_HELLO_OTEL";
+  public static final String ENV_OTEL_ENABLED = "GRPC_HELLO_OTEL";
 
-    private OtelSupport() {}
+  private OtelSupport() {}
 
-    public static boolean otelEnabled() {
-        return "Y".equals(System.getenv(ENV_OTEL_ENABLED));
+  public static boolean otelEnabled() {
+    return "Y".equals(System.getenv(ENV_OTEL_ENABLED));
+  }
+
+  /**
+   * Install a logging-exporter-backed TracerProvider as the global SDK and return the same SDK so
+   * callers can pass it through to GrpcTelemetry.builder(). Returns a no-op SDK
+   * (OpenTelemetry.noop()) when the env var is off, so the deferred call at main is always safe.
+   */
+  public static OpenTelemetry initOtel(String serviceName) {
+    if (!otelEnabled()) {
+      return OpenTelemetry.noop();
     }
+    Resource resource =
+        Resource.getDefault()
+            .merge(Resource.create(Attributes.of(ResourceAttributes.SERVICE_NAME, serviceName)));
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder()
+            .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
+            .setResource(resource)
+            .build();
+    return OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+  }
 
-    /**
-     * Install a logging-exporter-backed TracerProvider as the global
-     * SDK and return the same SDK so callers can pass it through to
-     * GrpcTelemetry.builder(). Returns a no-op SDK
-     * (OpenTelemetry.noop()) when the env var is off, so the
-     * deferred call at main is always safe.
-     */
-    public static OpenTelemetry initOtel(String serviceName) {
-        if (!otelEnabled()) {
-            return OpenTelemetry.noop();
-        }
-        Resource resource = Resource.getDefault()
-                .merge(Resource.create(Attributes.of(
-                        ResourceAttributes.SERVICE_NAME, serviceName)));
-        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
-                .addSpanProcessor(SimpleSpanProcessor.create(LoggingSpanExporter.create()))
-                .setResource(resource)
-                .build();
-        return OpenTelemetrySdk.builder()
-                .setTracerProvider(tracerProvider)
-                .build();
+  /**
+   * Returns the OpenTelemetry {@code TracingServerInterceptor} (or {@code null} when OTel is off).
+   * Caller wraps a {@code ServerServiceDefinition} via {@code ServerInterceptors.intercept(...)}.
+   */
+  public static ServerInterceptor serverInterceptor(OpenTelemetry openTelemetry) {
+    if (!otelEnabled()) {
+      return null;
     }
+    GrpcTelemetry grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build();
+    return new TracingServerInterceptor(grpcTelemetry);
+  }
 
-    /**
-     * Returns the OpenTelemetry {@code TracingServerInterceptor}
-     * (or {@code null} when OTel is off). Caller wraps a
-     * {@code ServerServiceDefinition} via {@code ServerInterceptors.intercept(...)}.
-     */
-    public static ServerInterceptor serverInterceptor(OpenTelemetry openTelemetry) {
-        if (!otelEnabled()) {
-            return null;
-        }
-        GrpcTelemetry grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build();
-        return new TracingServerInterceptor(grpcTelemetry);
+  /**
+   * Returns the OpenTelemetry {@code TracingClientInterceptor} (or {@code null} when OTel is off).
+   * Caller chains it via {@code ClientInterceptors.intercept(channel, ...)}.
+   */
+  public static ClientInterceptor clientInterceptor(OpenTelemetry openTelemetry) {
+    if (!otelEnabled()) {
+      return null;
     }
+    GrpcTelemetry grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build();
+    return new TracingClientInterceptor(grpcTelemetry);
+  }
 
-    /**
-     * Returns the OpenTelemetry {@code TracingClientInterceptor}
-     * (or {@code null} when OTel is off). Caller chains it via
-     * {@code ClientInterceptors.intercept(channel, ...)}.
-     */
-    public static ClientInterceptor clientInterceptor(OpenTelemetry openTelemetry) {
-        if (!otelEnabled()) {
-            return null;
-        }
-        GrpcTelemetry grpcTelemetry = GrpcTelemetry.builder(openTelemetry).build();
-        return new TracingClientInterceptor(grpcTelemetry);
-    }
+  /**
+   * Force the Tracer to be available globally so any service-side manual span emission has a
+   * configured tracer to use.
+   */
+  public static Tracer tracer(OpenTelemetry openTelemetry) {
+    return openTelemetry.getTracer("hello-grpc-java");
+  }
 
-    /** Force the Tracer to be available globally so any service-side
-     *  manual span emission has a configured tracer to use. */
-    public static Tracer tracer(OpenTelemetry openTelemetry) {
-        return openTelemetry.getTracer("hello-grpc-java");
-    }
-
-    /** Marker onAttribute() re-export to avoid breaking the ResourceAttributes
-     *  AttributeKey API surface for callers. */
-    public static AttributeKey<String> serviceNameKey() {
-        return ResourceAttributes.SERVICE_NAME;
-    }
+  /**
+   * Marker onAttribute() re-export to avoid breaking the ResourceAttributes AttributeKey API
+   * surface for callers.
+   */
+  public static AttributeKey<String> serviceNameKey() {
+    return ResourceAttributes.SERVICE_NAME;
+  }
 }

--- a/hello-grpc-java/src/main/java/org/feuyeux/grpc/server/ProtoServer.java
+++ b/hello-grpc-java/src/main/java/org/feuyeux/grpc/server/ProtoServer.java
@@ -18,6 +18,7 @@ import io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.services.ProtoReflectionService;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.opentelemetry.api.OpenTelemetry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -27,9 +28,8 @@ import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import org.feuyeux.grpc.client.HeaderClientInterceptor;
 import org.feuyeux.grpc.common.Connection;
-import org.feuyeux.grpc.proto.LandingServiceGrpc;
-import io.opentelemetry.api.OpenTelemetry;
 import org.feuyeux.grpc.common.OtelSupport;
+import org.feuyeux.grpc.proto.LandingServiceGrpc;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -220,8 +220,7 @@ public class ProtoServer {
     }
     ServerServiceDefinition interceptedService =
         ServerInterceptors.intercept(
-            landingService,
-            chain.toArray(new io.grpc.ServerInterceptor[0]));
+            landingService, chain.toArray(new io.grpc.ServerInterceptor[0]));
 
     // Determine if secure mode is enabled
     String secureMode = System.getenv(GRPC_HELLO_SECURE);


### PR DESCRIPTION
## Summary
- `OtelSupport.java`: reformat (2-space indent, condensed javadoc, single-line `Resource` build). No behavioral change.
- `ProtoServer.java`: reorder imports to put `org.feuyeux.grpc.proto.LandingServiceGrpc` after `io.opentelemetry.api.OpenTelemetry` to match google-java-format conventions.
- `ProtoClient.java`: drop unused `ClientInterceptor` import; inline single-use interceptor array.

## Verification
- ./gradlew compileJava (gated on local toolchain).